### PR TITLE
Add input format verification

### DIFF
--- a/components/EvmSend.tsx
+++ b/components/EvmSend.tsx
@@ -63,12 +63,10 @@ const EvmSend: React.FC<EvmSendProps> = ({
       const args: any[] | undefined = buildArguments(keyValueStore);
 
       let extraArguments: any | undefined = {};
-      let feeString = '';
       if (feeKey !== undefined) {
         // TODO: validate argument
         try {
           extraArguments["value"] = ethers.toBigInt(keyValueStore[feeKey]);
-          feeString = keyValueStore[feeKey];
         } catch (error) {
           extraArguments = undefined;
         }

--- a/components/Input.tsx
+++ b/components/Input.tsx
@@ -1,8 +1,10 @@
 import React, {useEffect, useState} from 'react';
 import { useGlobalContext } from '../contexts/GlobalContext';
+import {InputFormat} from '../utils/InputFormat';
 
 interface InputProps {
   id: string,
+  format?: InputFormat
 }
 
 /**
@@ -13,8 +15,10 @@ interface InputProps {
  */
 const Input: React.FC<InputProps> = ({
                                        id,
+                                       format
                                      }) => {
   const { keyValueStore, setKeyValueStore } = useGlobalContext();
+  const [ errorMessage, setErrorMessage ] = useState<string | undefined>(undefined);
 
   const handleQueryChange = (key: string, value: string) => {
     setKeyValueStore((prev) => {
@@ -22,19 +26,30 @@ const Input: React.FC<InputProps> = ({
       if (value === '') {
         delete next[key]
       }
+
+      // generate an error message if the value is populated and has an expected format.
+      if (value != '' && format !== undefined) {
+        setErrorMessage(format(value));
+      } else {
+        setErrorMessage(undefined);
+      }
+
       return next;
     });
   };
 
-  return (<input
+  return (<div>
+    <input
               type="text"
               id={id}
               name={id}
               value={keyValueStore[id] ? keyValueStore[id] : ''}
               onChange={(e) => handleQueryChange(id, e.target.value)}
-              className={"context-input"}
+              className={"input-box"}
             />
-          );
+      <p className={"input-error"}>{errorMessage}</p>
+    </div>
+  );
 };
 
 export default Input;

--- a/contexts/GlobalContext.tsx
+++ b/contexts/GlobalContext.tsx
@@ -31,8 +31,8 @@ export interface GlobalContextData {
 export type NetworkType = "mainnet" | "testnet";
 
 export const PriceServiceUrls: Record<string, string> = {
-  "mainnet": "https://xc-mainnet.pyth.network/",
-  "testnet": "https://xc-testnet.pyth.network/",
+  "mainnet": "https://xc-mainnet.pyth.network",
+  "testnet": "https://xc-testnet.pyth.network",
 }
 
 export interface EvmNetworkConfig {

--- a/pages/evm/get-price.mdx
+++ b/pages/evm/get-price.mdx
@@ -1,5 +1,6 @@
 import Input from '../../components/Input';
 import Arg from '../../components/Arg';
+import {InputFormats} from '../../utils/InputFormat';
 import Example from '../../components/Example';
 import DynamicCode from '../../components/DynamicCode';
 import DisplayKeyValueStore from '../../components/DisplayKeyValueStore';
@@ -25,7 +26,7 @@ reading it. This step ensures that the on-chain price is fresh.
 
 | Argument                                      |  | Description |
 |-----------------------------------------| --- | --- |
-| <Arg required={true} type="hex">id</Arg> | <Input id="id" /> | The ID of the price feed you want to read |
+| <Arg required={true} type="hex">id</Arg> | <Input id="id" format={InputFormats.ZeroX} /> | The ID of the price feed you want to read |
 
 Examples:
 <Example keyValues={{

--- a/pages/evm/get-update-fee.mdx
+++ b/pages/evm/get-update-fee.mdx
@@ -1,5 +1,6 @@
 import Input from '../../components/Input';
 import Arg from '../../components/Arg';
+import {InputFormats} from '../../utils/InputFormat';
 import Example from '../../components/Example';
 import DynamicCode from '../../components/DynamicCode';
 import DisplayKeyValueStore from '../../components/DisplayKeyValueStore';
@@ -15,7 +16,7 @@ The `updateData` can be retrieved from the price service API.
 
 | Argument                                                  |                           | Description                                                                                               |
 |-----------------------------------------------------------|---------------------------|-----------------------------------------------------------------------------------------------------------|
-| <Arg required={true} type="hex[]">updateData</Arg>        | <Input id="updateData" /> | The price updates that you would like to submit to [updatePriceFeeds](update-price-feeds) |
+| <Arg required={true} type="hex[]">updateData</Arg>        | <Input id="updateData" format={InputFormats.ZeroX}/> | The price updates that you would like to submit to [updatePriceFeeds](update-price-feeds) |
 
 Examples:
 <Example

--- a/pages/evm/update-price-feeds.mdx
+++ b/pages/evm/update-price-feeds.mdx
@@ -1,5 +1,6 @@
 import Input from '../../components/Input';
 import Arg from '../../components/Arg';
+import {InputFormats} from '../../utils/InputFormat';
 import Example from '../../components/Example';
 import DynamicCode from '../../components/DynamicCode';
 import EvmSend from '../../components/EvmSend';
@@ -13,8 +14,8 @@ You can retrieve these data payloads using the Price Service API.
 
 | Argument                                                  |                           | Description                                       |
 |-----------------------------------------------------------|---------------------------|---------------------------------------------------|
-| <Arg required={true} type="hex[]">updateData</Arg>        | <Input id="updateData" /> | The price update data for the contract to verify. |
-| <Arg required={true} type="wei">fee</Arg>                    | <Input id="fee" />           | The update fee in wei. This fee is sent as the value of the transaction. |
+| <Arg required={true} type="hex[]">updateData</Arg>        | <Input id="updateData" format={InputFormats.ZeroX} /> | The price update data for the contract to verify. |
+| <Arg required={true} type="wei">fee</Arg>                    | <Input id="fee" format={InputFormats.BigInt}/>           | The update fee in wei. This fee is sent as the value of the transaction. |
 
 <Example
     keyValues={{

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -34,8 +34,12 @@ th {
     color: red;
 }
 
-.context-input {
+.input-box {
     min-width: 200px;
+}
+
+.input-error {
+    color: red;
 }
 
 button {
@@ -67,3 +71,4 @@ button {
     background-color: rgba(0, 0, 0, 0.5); /* Set the background color with transparency */
     z-index: 1; /* Set the pseudo-element's z-index lower than the element */
 }
+

--- a/utils/InputFormat.tsx
+++ b/utils/InputFormat.tsx
@@ -1,0 +1,32 @@
+import {ethers} from 'ethers';
+
+// Checks whether the value of an input is a valid value.
+// Returns undefined if valid, or an error message string if invalid.
+export type InputFormat = (string) => string | undefined;
+
+function regexFormat(regex: string, errorMessage: string) {
+  const regexObj = new RegExp(regex);
+  return (x: string) => {
+    if (regexObj.test(x)) {
+      return undefined;
+    } else {
+      return errorMessage;
+    }
+  }
+}
+
+function bigIntInputFormat(x: string): string | undefined {
+  try {
+    ethers.toBigInt(x);
+    return undefined;
+  } catch (error) {
+    return 'Please enter a valid number, for example "1"';
+  }
+}
+
+export const InputFormats: Record<string, InputFormat> = {
+  // The 0| condition below means we don't show an error message when the user starts typing 0 as the first character.
+  ZeroX: regexFormat('^(0|0x[0-9A-Fa-f]*)$', 'Please enter a hexadecimal string prefixed with 0x, for example "0xa19f"'),
+  Hex: regexFormat('^[0-9A-Fa-f]*$', 'Please enter a hexadecimal string prefixed with 0x, for example "a19f"'),
+  BigInt: bigIntInputFormat
+}


### PR DESCRIPTION
This PR adds an InputFormat class that you can specify with Inputs. The format will check if the entered value is of the appropriate type (hex string, etc). If not, it will return an error message that is displayed by the input.

The error messages interact a little weirdly with the input argument tables right now (they resize the table when they show up). Let's circle back on that when we get to styling things properly though.