### PR TITLE
Make ethers contract easier to access & use in Example

### DIFF
--- a/components/ContractInfo.tsx
+++ b/components/ContractInfo.tsx
@@ -1,5 +1,4 @@
 import React, { useEffect, useState } from "react";
-import { ethers } from "ethers";
 import { useGlobalContext } from "../contexts/GlobalContext";
 import EvmNetworkSelector from "./EvmNetworkSelector";
 
@@ -8,28 +7,25 @@ import EvmNetworkSelector from "./EvmNetworkSelector";
  * the configuration of the Pyth contract deployed on that network.
  */
 const ContractInfo = () => {
-  const { provider, networkConfig, pythContractAbi } = useGlobalContext();
+  const { networkConfig, pythContract } = useGlobalContext();
 
   const [fee, setFee] = useState<string>("loading...");
   const [validTimePeriod, setValidTimePeriod] = useState<string>("loading...");
 
   useEffect(() => {
     async function helper() {
-      const contract = new ethers.Contract(
-        networkConfig.pythAddress,
-        pythContractAbi,
-        provider
-      );
       try {
-        setFee((await contract.getUpdateFee(["0x01"])).toString());
-        setValidTimePeriod((await contract.getValidTimePeriod()).toString());
+        setFee((await pythContract.getUpdateFee(["0x01"])).toString());
+        setValidTimePeriod(
+          (await pythContract.getValidTimePeriod()).toString()
+        );
       } catch (error: any) {
         setFee("loading...");
         setValidTimePeriod("loading...");
       }
     }
     helper();
-  }, [provider, networkConfig, pythContractAbi]);
+  }, [pythContract]);
 
   return (
     <div>

--- a/components/DynamicCode.tsx
+++ b/components/DynamicCode.tsx
@@ -45,8 +45,6 @@ const DynamicCode = ({ targets, children }: DynamicCodeProps) => {
     if (divRef.current && !targetRefs.current) {
       const tokens = [];
       for (const [target, replacement] of Object.entries(targets)) {
-        console.log(`target: ${target}`);
-
         // TODO: may need to find more than one
         // note: this explicitly filters out entire lines and only finds spans within lines
         // to preserve highlighting

--- a/components/EvmCall.tsx
+++ b/components/EvmCall.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from "react";
-import { ethers, isError, Result } from "ethers";
+import { isError, Result } from "ethers";
 import { useGlobalContext } from "../contexts/GlobalContext";
 
 interface EvmCallProps {

--- a/components/EvmCall.tsx
+++ b/components/EvmCall.tsx
@@ -24,20 +24,13 @@ const EvmCall = ({ functionName, buildArguments }: EvmCallProps) => {
   const [responsePreface, setResponsePreface] = useState<string>("");
   const [isStale, setIsStale] = useState<boolean>(false);
 
-  const { keyValueStore, provider, networkConfig, pythContractAbi } =
-    useGlobalContext();
+  const { keyValueStore, pythContract } = useGlobalContext();
 
   useEffect(() => {
     setIsStale(true);
   }, [keyValueStore]);
 
   const sendTransaction = async () => {
-    const contract = new ethers.Contract(
-      networkConfig.pythAddress,
-      pythContractAbi,
-      provider
-    );
-
     const args: any[] | undefined = buildArguments(keyValueStore);
 
     // TODO: validate arguments
@@ -46,9 +39,9 @@ const EvmCall = ({ functionName, buildArguments }: EvmCallProps) => {
       setIsStale(false);
     } else {
       try {
-        const result: Result = await contract[functionName].staticCallResult(
-          ...args
-        );
+        const result: Result = await pythContract[
+          functionName
+        ].staticCallResult(...args);
         const resultString = renderResult(result, "");
 
         setResponsePreface("EVM call succeeded with result:");
@@ -56,7 +49,7 @@ const EvmCall = ({ functionName, buildArguments }: EvmCallProps) => {
         setIsStale(false);
       } catch (error) {
         if (isError(error, "CALL_EXCEPTION")) {
-          const ethError = contract.interface.parseError(error.data);
+          const ethError = pythContract.interface.parseError(error.data);
           setResponsePreface("EVM call reverted with exception:");
           setResponse(`${ethError.name}(${renderResult(ethError.args, "")})`);
           setIsStale(false);

--- a/components/EvmSend.tsx
+++ b/components/EvmSend.tsx
@@ -22,15 +22,8 @@ interface EvmSendProps {
  * TODO: probably better to pass the contract address / ABI as arguments (?)
  */
 const EvmSend = ({ functionName, buildArguments, feeKey }: EvmSendProps) => {
-  const {
-    keyValueStore,
-    provider,
-    setProvider,
-    signer,
-    setSigner,
-    networkConfig,
-    pythContractAbi,
-  } = useGlobalContext();
+  const { keyValueStore, setProvider, signer, setSigner, pythContract } =
+    useGlobalContext();
 
   const [response, setResponse] = useState<string | undefined>(undefined);
 
@@ -60,12 +53,7 @@ const EvmSend = ({ functionName, buildArguments, feeKey }: EvmSendProps) => {
 
   const sendTransaction = async () => {
     if (signer != undefined) {
-      const contract = new ethers.Contract(
-        networkConfig.pythAddress,
-        pythContractAbi,
-        provider
-      );
-      const contractWithSigner = contract.connect(signer);
+      const contractWithSigner = pythContract.connect(signer);
 
       const args: any[] | undefined = buildArguments(keyValueStore);
 

--- a/components/Example.tsx
+++ b/components/Example.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo } from "react";
-import { ethers, isError, Result } from "ethers";
+import { ethers } from "ethers";
 import {
   NetworkType,
   PriceServiceUrls,

--- a/components/Example.tsx
+++ b/components/Example.tsx
@@ -28,17 +28,9 @@ const Example = ({ keyValues, children }: ExampleProps) => {
     () =>
       new ExampleRenderingContext(
         globalContext.networkConfig.networkType,
-        new ethers.Contract(
-          globalContext.networkConfig.pythAddress,
-          globalContext.pythContractAbi,
-          globalContext.provider
-        )
+        globalContext.pythContract
       ),
-    [
-      globalContext.networkConfig,
-      globalContext.pythContractAbi,
-      globalContext.provider,
-    ]
+    [globalContext.networkConfig, globalContext.pythContract]
   );
 
   const handleClick = () => {

--- a/contexts/GlobalContext.tsx
+++ b/contexts/GlobalContext.tsx
@@ -65,6 +65,7 @@ export const Networks: Record<string, EvmNetworkConfig> = {
     info: {
       chainId: "0x1", // Ethereum Mainnet
       chainName: "Ethereum Mainnet",
+      // FIXME: this url obviously doesn't work
       rpcUrls: ["https://mainnet.infura.io/v3/YOUR_INFURA_PROJECT_ID"],
       nativeCurrency: {
         name: "Ether",

--- a/contexts/GlobalContext.tsx
+++ b/contexts/GlobalContext.tsx
@@ -6,7 +6,7 @@ import React, {
   useState,
   useMemo,
 } from "react";
-import { ethers, InterfaceAbi } from "ethers";
+import { ethers } from "ethers";
 
 /** Global information available to all components on any page. */
 export interface GlobalContextData {

--- a/contexts/GlobalContext.tsx
+++ b/contexts/GlobalContext.tsx
@@ -4,6 +4,7 @@ import React, {
   useContext,
   useEffect,
   useState,
+  useMemo,
 } from "react";
 import { ethers, InterfaceAbi } from "ethers";
 
@@ -32,8 +33,8 @@ export interface GlobalContextData {
   signer: ethers.Signer | undefined;
   setSigner: React.Dispatch<React.SetStateAction<ethers.Signer | undefined>>;
 
-  // ABI of the pyth contract on the current chain
-  pythContractAbi: InterfaceAbi;
+  // The pyth contract on the current chain
+  pythContract: ethers.Contract;
 }
 
 export type NetworkType = "mainnet" | "testnet";
@@ -132,9 +133,19 @@ export const GlobalContextProvider = ({
   );
   const [signer, setSigner] = useState<ethers.Signer | undefined>(undefined);
 
-  const iPythAbi = require("../abis/IPyth.json");
-  const errorAbi = require("../abis/PythErrors.json");
-  const contractAbi = iPythAbi.concat(errorAbi);
+  const contractAbi = useMemo(() => {
+    const iPythAbi = require("../abis/IPyth.json");
+    const errorAbi = require("../abis/PythErrors.json");
+    return iPythAbi.concat(errorAbi);
+  }, []);
+
+  const pythContract = useMemo(() => {
+    return new ethers.Contract(
+      networkConfig.pythAddress,
+      contractAbi,
+      provider
+    );
+  }, [networkConfig, contractAbi, provider]);
 
   useEffect(() => {
     async function helper() {
@@ -165,7 +176,7 @@ export const GlobalContextProvider = ({
         setProvider,
         signer,
         setSigner,
-        pythContractAbi: contractAbi,
+        pythContract: pythContract,
       }}
     >
       {children}

--- a/pages/_meta.json
+++ b/pages/_meta.json
@@ -9,7 +9,7 @@
     "type": "page"
   },
   "api-explorer": {
-    "title": "API Explorer",
+    "title": "API Reference",
     "type": "menu",
     "items": {
       "evm": {

--- a/pages/evm/update-price-feeds.mdx
+++ b/pages/evm/update-price-feeds.mdx
@@ -21,7 +21,13 @@ You can retrieve these data payloads using the Price Service API.
 <Example
   keyValues={{
     updateData: (ctx) => ctx.getLatestVaa("Crypto.BTC/USD"),
-    fee: (ctx) => "1", // FIXME this needs to be populated correctly
+    fee: (ctx) => {
+      // NOTE: this technically could get the update fee for a different VAA than the one above.
+      // This shouldn't affect the update fee as long as the fee is only dependent on the price feed ids
+      // and not the specific content of the price update.
+      let vaa = ctx.getLatestVaa("Crypto.BTC/USD");
+      return ctx.getUpdateFee([vaa]);
+    },
   }}
 >
   Latest BTC/USD update data


### PR DESCRIPTION
One of the remaining todos on this repo was to make the EVM contract queryable from the Example component, so that we could fill in the update fee in example calls to updatePriceFeeds. This PR refactors the global context so that the contract is stored within it, then uses that in Example to perform the necessary query.