### PR TITLE
use JsonRpcProvider instead of BrowserProvider

### DIFF
--- a/components/ContractInfo.tsx
+++ b/components/ContractInfo.tsx
@@ -9,54 +9,67 @@ import EvmNetworkSelector from "./EvmNetworkSelector";
 const ContractInfo = () => {
   const { networkConfig, pythContract } = useGlobalContext();
 
-  const [fee, setFee] = useState<string>("loading...");
-  const [validTimePeriod, setValidTimePeriod] = useState<string>("loading...");
+  const [fee, setFee] = useState<string>();
+  const [validTimePeriod, setValidTimePeriod] = useState<string>();
+
+  const [isLoading, setIsLoading] = useState<boolean>(false);
 
   useEffect(() => {
     async function helper() {
       try {
+        setIsLoading(true);
         setFee((await pythContract.getUpdateFee(["0x01"])).toString());
         setValidTimePeriod(
           (await pythContract.getValidTimePeriod()).toString()
         );
+        setIsLoading(false);
       } catch (error: any) {
         console.error(error);
-        setFee("loading...");
-        setValidTimePeriod("loading...");
+        setIsLoading(false);
       }
     }
     helper();
   }, [pythContract]);
 
+  const configValue = (value: string) => {
+    return isLoading ? "Loading..." : value;
+  };
+
   return (
     <div>
       <EvmNetworkSelector />
-      <table className="w-full text-left">
+      <table className="w-full text-left table-fixed">
         <tbody>
           <tr
             key="Contract Address"
             className="border-t border-darkGray5 bg-darkGray border-none"
           >
-            <td className="py-3 pl-6 pr-1 lg:pl-14">Contract Address</td>
-            <td className="py-3 pl-1 lg:pl-14">{networkConfig.pythAddress}</td>
+            <td className="py-3 pl-6 pr-1 lg:pl-14 w-48">Contract Address</td>
+            <td className="py-3 pl-1 lg:pl-14">
+              {configValue(networkConfig.pythAddress)}
+            </td>
           </tr>
           <tr key="Chain ID" className="border-t border-darkGray5 bg-darkGray">
             <td className="py-3 pl-6 pr-1 lg:pl-14">Chain ID</td>
-            <td className="py-3 pl-1 lg:pl-14">{networkConfig.info.chainId}</td>
+            <td className="py-3 pl-1 lg:pl-14">
+              {configValue(networkConfig.info.chainId)}
+            </td>
           </tr>
           <tr
             key="Update Fee"
             className="border-t border-darkGray5 bg-darkGray"
           >
             <td className="py-3 pl-6 pr-1 lg:pl-14">Update Fee</td>
-            <td className="py-3 pl-1 lg:pl-14">{fee}</td>
+            <td className="py-3 pl-1 lg:pl-14">{configValue(fee)}</td>
           </tr>
           <tr
             key="Valid Time Period"
             className="border-t border-darkGray5 bg-darkGray border-none"
           >
             <td className="py-3 pl-6 pr-1 lg:pl-14">Valid Time Period</td>
-            <td className="py-3 pl-1 lg:pl-14">{validTimePeriod}</td>
+            <td className="py-3 pl-1 lg:pl-14">
+              {configValue(validTimePeriod)}
+            </td>
           </tr>
         </tbody>
       </table>

--- a/contexts/GlobalContext.tsx
+++ b/contexts/GlobalContext.tsx
@@ -1,7 +1,7 @@
-import { ethers } from "ethers";
+import { ethers, JsonRpcProvider } from "ethers";
 import React, {
-  ReactNode,
   createContext,
+  ReactNode,
   useContext,
   useEffect,
   useMemo,
@@ -67,7 +67,7 @@ export const Networks: Record<string, EvmNetworkConfig> = {
       chainId: "0x1", // Ethereum Mainnet
       chainName: "Ethereum Mainnet",
       // FIXME: this url obviously doesn't work
-      rpcUrls: ["https://mainnet.infura.io/v3/YOUR_INFURA_PROJECT_ID"],
+      rpcUrls: ["https://rpc.ankr.com/eth"],
       nativeCurrency: {
         name: "Ether",
         symbol: "ETH",
@@ -150,16 +150,9 @@ export const GlobalContextProvider = ({
   useEffect(() => {
     async function helper() {
       setNetworkConfig(Networks[networkName]);
-      await switchNetwork(networkName);
-      // @ts-ignore
-      if (window.ethereum) {
-        // @ts-ignore
-        setProvider(new ethers.BrowserProvider(window.ethereum));
-      } else {
-        setProvider(
-          ethers.getDefaultProvider(Networks[networkName].info.rpcUrls[0])
-        );
-      }
+      const rpcUrl = Networks[networkName].info.rpcUrls[0];
+      const provider = new JsonRpcProvider(rpcUrl);
+      setProvider(provider);
     }
     helper();
   }, [networkName]);
@@ -184,38 +177,39 @@ export const GlobalContextProvider = ({
   );
 };
 
-async function switchNetwork(networkName: string) {
-  const networkData = Networks[networkName];
+// TODO: use ConnectKit wallet adapter which supports switching networks
+// async function switchNetwork(networkName: string) {
+//   const networkData = Networks[networkName];
 
-  if (!networkData) {
-    throw new Error("Unsupported network");
-  }
+//   if (!networkData) {
+//     throw new Error("Unsupported network");
+//   }
 
-  // @ts-ignore
-  if (window.ethereum) {
-    // @ts-ignore
-    const ethereum = window.ethereum;
+//   // @ts-ignore
+//   if (window.ethereum) {
+//     // @ts-ignore
+//     const ethereum = window.ethereum;
 
-    try {
-      // Request the user to switch to the desired network
-      await ethereum.request({
-        method: "wallet_switchEthereumChain",
-        params: [{ chainId: networkData.info.chainId }],
-      });
-    } catch (error: any) {
-      // If the chain does not exist then add it
-      if (error.code === 4902) {
-        try {
-          await ethereum.request({
-            method: "wallet_addEthereumChain",
-            params: [networkData.info],
-          });
-        } catch (addError: any) {
-          console.error(addError);
-        }
-      }
+//     try {
+//       // Request the user to switch to the desired network
+//       await ethereum.request({
+//         method: "wallet_switchEthereumChain",
+//         params: [{ chainId: networkData.info.chainId }],
+//       });
+//     } catch (error: any) {
+//       // If the chain does not exist then add it
+//       if (error.code === 4902) {
+//         try {
+//           await ethereum.request({
+//             method: "wallet_addEthereumChain",
+//             params: [networkData.info],
+//           });
+//         } catch (addError: any) {
+//           console.error(addError);
+//         }
+//       }
 
-      console.error(error);
-    }
-  }
-}
+//       console.error(error);
+//     }
+//   }
+// }


### PR DESCRIPTION
use JsonRpcProvider instead of BrowserProvider because for e.g. Contract Configuration is a read-only operation and shouldnt require users to install a wallet to browse the page, as for switching networks, as dicussed previously, we can use wallet adapters which will provide the functionality, will follow up on a separate PR