### PR TITLE
Update aptos cli release link

### DIFF
--- a/pages/aptos/sdks.mdx
+++ b/pages/aptos/sdks.mdx
@@ -17,7 +17,7 @@ Aptos contracts can program against the Pyth contract's interface by including i
 
         Note that this dependency references the latest version of the Pyth contract code.
         You can also choose the most recent git sha in order to have a repeatable build.
-        This contract was compiled with [aptos-cli v1.0.4](https://github.com/aptos-labs/aptos-core/releases/download/aptos-cli-v1.0.4/aptos-cli-1.0.4-Ubuntu-22.04-x86_64.zip).
+        This contract was compiled with [aptos-cli v1.0.4](https://github.com/aptos-labs/aptos-core/releases/tag/aptos-cli-v1.0.4).
 
         Next, add the following named addresses to the `[addresses]` section of `Move.toml`:
 


### PR DESCRIPTION
Replace link from ubuntu zip file to general release page so that users in mac can easily find the relevant link too