### PR TITLE
Remove shimmer testnet contract

### DIFF
--- a/pages/documentation/pythnet-price-feeds/evm.mdx
+++ b/pages/documentation/pythnet-price-feeds/evm.mdx
@@ -64,7 +64,6 @@ Pyth is currently available on the following EVM networks:
 | Arbitrum Goerli (testnet)   | [`0x939C0e902FF5B3F7BA666Cc8F6aC75EE76d3f900`](https://goerli.arbiscan.io/address/0x939C0e902FF5B3F7BA666Cc8F6aC75EE76d3f900)                   |
 | zkSync Era Goerli (testnet) | [`0xC38B1dd611889Abc95d4E0a472A667c3671c08DE`](https://goerli.explorer.zksync.io/address/0xC38B1dd611889Abc95d4E0a472A667c3671c08DE)            |
 | Base Goerli (testnet)       | [`0x5955C1478F0dAD753C7E2B4dD1b4bC530C64749f`](https://goerli.basescan.org/address/0x5955c1478f0dad753c7e2b4dd1b4bc530c64749f)                  |
-| Shimmer testnet             | [`0xA2aa501b19aff244D90cc15a4Cf739D2725B5729`](https://explorer.evm.testnet.shimmer.network/address/0xA2aa501b19aff244D90cc15a4Cf739D2725B5729) |
 | Chiado (Gnosis testnet)     | [`0xdDAf6D29b8bc81c1F0798a5e4c264ae89c16a72B`](https://blockscout.com/gnosis/chiado/address/0xdDAf6D29b8bc81c1F0798a5e4c264ae89c16a72B)         |
 | EVMOS testnet               | [`0x354bF866A4B006C9AF9d9e06d9364217A8616E12`](https://evm.evmos.dev/address/0x354bF866A4B006C9AF9d9e06d9364217A8616E12)                        |
 | Neon devnet                 | [`0x2FF312f50689ad279ABb164dB255Eb568733BD6c`](https://devnet.neonscan.org/address/0x2FF312f50689ad279ABb164dB255Eb568733BD6c)                  |


### PR DESCRIPTION
The address led to nowhere as the old network was deprecated