### PR TITLE
Update pyth-client-websocket-api.mdx

### DIFF
--- a/pages/documentation/publish-data/pyth-client-websocket-api.mdx
+++ b/pages/documentation/publish-data/pyth-client-websocket-api.mdx
@@ -99,7 +99,7 @@ The request includes the pricing account from the get_product_list output and lo
 }
 ```
 
-The price and confidence interval (conf) attributes are expressed as integers with an implied decimal point given by the price*exponent defined by the symbol. The price type is a string with one of the following values: "price" or "ema*\_price". The symbol status is a string with one of the following values: "trading" or "halted".
+The price and confidence interval (conf) attributes are expressed as integers with an implied decimal point given by the price*exponent defined by the symbol. The price type is a string with one of the following values: "price" or "ema*\_price". The symbol status is a string with one of the following values: "trading" or "unknown".
 
 A successful response looks like:
 


### PR DESCRIPTION
changed term halted to 'unknown' since publishers should not be using the halted status unless a ticker has expired. unknown is the correct status if a publisher is down for maintenance or for out of market hours.