### PR TITLE
[cosmwasm] Remove unauthorized inj contract

### DIFF
--- a/pages/documentation/pythnet-price-feeds/cosmwasm.mdx
+++ b/pages/documentation/pythnet-price-feeds/cosmwasm.mdx
@@ -32,7 +32,6 @@ Pyth is currently available on the following cosmwasm chains:
 | Injective Mainnet | `inj12j43nf2f0qumnt2zrrmpvnsqgzndxefujlvr08`                         |
 | Osmosis Mainnet   | `osmo13ge29x4e2s63a8ytz2px8gurtyznmue4a69n5275692v3qn3ks8q7cwck7`    |
 | Neutron Mainnet   | `neutron1m2emc93m9gpwgsrsf2vylv9xvgqh654630v7dfrhrkmr5slly53spg85wv` |
-| Injective Testnet | `inj18hckkzqf47mdhd734g6papk6wj20y24rm43sk9`                         |
 | Osmosis Test 5    | `osmo1hpdzqku55lmfmptpyj6wdlugqs5etr6teqf7r4yqjjrxjznjhtuqqu5kdh`    |
 | Sei Atlantic 2    | `sei1w2rxq6eckak47s25crxlhmq96fzjwdtjgdwavn56ggc0qvxvw7rqczxyfy`     |
 | Sei Pacific 1     | `sei15d2tyq2jzxmpg32y3am3w62dts32qgzmds9qnr6c87r0gwwr7ynqal0x38`     |


### PR DESCRIPTION
This contract is not authorized for injective price relay, so devs may get confused if they want to use it. It's better to remove it for now until it's fixed from injective side.