### PR TITLE
evm: replace testnet contracts with their stable version

### DIFF
--- a/pages/documentation/pythnet-price-feeds/evm.mdx
+++ b/pages/documentation/pythnet-price-feeds/evm.mdx
@@ -87,6 +87,7 @@ Pyth is currently available on the following EVM networks using Pyth Stable data
 | Mumbai (Polygon testnet)    | [`0xFC6bd9F9f0c6481c6Af3A7Eb46b296A5B85ed379`](https://mumbai.polygonscan.com/address/0xFC6bd9F9f0c6481c6Af3A7Eb46b296A5B85ed379)                 |
 | Neon devnet                 | [`0x0708325268dF9F66270F1401206434524814508b`](https://devnet.neonscan.org/address/0x0708325268dF9F66270F1401206434524814508b)                    |
 | Optimism Goerli (testnet)   | [`0xDd24F84d36BF92C65F92307595335bdFab5Bbd21`](https://goerli-optimism.etherscan.io/address/0xDd24F84d36BF92C65F92307595335bdFab5Bbd21)           |
+| Optimism Sepolia (testnet)  | [`0x0708325268dF9F66270F1401206434524814508b`](https://optimism-sepolia.blockscout.com/address/0x0708325268dF9F66270F1401206434524814508b)        |
 | Polygon zkEVM testnet       | [`0xFf255f800044225f54Af4510332Aa3D67CC77635`](https://testnet-zkevm.polygonscan.com/address/0xFf255f800044225f54Af4510332Aa3D67CC77635)          |
 | Saigon (Ronin testnet)      | [`0xEbe57e8045F2F230872523bbff7374986E45C486`](https://saigon-app.roninchain.com/address/0xEbe57e8045F2F230872523bbff7374986E45C486)              |
 | Scroll Sepolia              | [`0x41c9e39574F40Ad34c79f1C99B66A45eFB830d4c`](https://sepolia-blockscout.scroll.io/address/0x41c9e39574F40Ad34c79f1C99B66A45eFB830d4c)           |
@@ -97,12 +98,11 @@ Pyth is currently available on the following EVM networks using Pyth Stable data
 | Zetachain testnet           | [`0x0708325268dF9F66270F1401206434524814508b`](https://explorer.zetachain.com/address/0x0708325268dF9F66270F1401206434524814508b)                 |
 | zkSync Era Goerli (testnet) | [`0x8739d5024B5143278E2b15Bd9e7C26f6CEc658F1`](https://goerli.explorer.zksync.io/address/0x8739d5024B5143278E2b15Bd9e7C26f6CEc658F1)              |
 
-Pyth is available on the following networks using Pyth Beta data sources:
+Pyth is available on the following network using Pyth Beta data sources:
 
-| Network                    | Contract address                                                                                                                           |
-| -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
-| Horizen GOBI testnet       | [`0xA2aa501b19aff244D90cc15a4Cf739D2725B5729`](https://gobi-explorer.horizenlabs.io/address/0xA2aa501b19aff244D90cc15a4Cf739D2725B5729)    |
-| Optimism Sepolia (testnet) | [`0x2880aB155794e7179c9eE2e38200202908C17B43`](https://optimism-sepolia.blockscout.com/address/0x2880aB155794e7179c9eE2e38200202908C17B43) |
+| Network              | Contract address                                                                                                                        |
+| -------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
+| Horizen GOBI testnet | [`0xA2aa501b19aff244D90cc15a4Cf739D2725B5729`](https://gobi-explorer.horizenlabs.io/address/0xA2aa501b19aff244D90cc15a4Cf739D2725B5729) |
 
 ## Price Feed IDs
 

--- a/pages/documentation/pythnet-price-feeds/evm.mdx
+++ b/pages/documentation/pythnet-price-feeds/evm.mdx
@@ -16,94 +16,94 @@ This application is an AMM that allows users to swap two assets at the Pyth-prov
 
 ## Networks
 
-Pyth is currently available on the following EVM networks:
+Pyth is currently available on the following EVM networks using Pyth Stable data sources:
 
-### Stable
+## Mainnets
 
 | Network        | Contract address                                                                                                                          |
 | -------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
-| Avalanche      | [`0x4305FB66699C3B2702D4d05CF36551390A4c69C6`](https://snowtrace.io/address/0x4305fb66699c3b2702d4d05cf36551390a4c69c6)                   |
-| Fantom         | [`0xff1a0f4744e8582DF1aE09D5611b887B6a12925C`](https://ftmscan.com/address/0xff1a0f4744e8582df1ae09d5611b887b6a12925c)                    |
-| Polygon        | [`0xff1a0f4744e8582DF1aE09D5611b887B6a12925C`](https://polygonscan.com/address/0xff1a0f4744e8582df1ae09d5611b887b6a12925c)                |
-| BNB            | [`0x4D7E825f80bDf85e913E0DD2A2D54927e9dE1594`](https://bscscan.com/address/0x4d7e825f80bdf85e913e0dd2a2d54927e9de1594)                    |
-| Ethereum       | [`0x4305FB66699C3B2702D4d05CF36551390A4c69C6`](https://etherscan.io/address/0x4305fb66699c3b2702d4d05cf36551390a4c69c6)                   |
-| Optimism       | [`0xff1a0f4744e8582DF1aE09D5611b887B6a12925C`](https://optimistic.etherscan.io/address/0xff1a0f4744e8582df1ae09d5611b887b6a12925c)        |
-| Aurora         | [`0xF89C7b475821EC3fDC2dC8099032c05c6c0c9AB9`](https://explorer.aurora.dev/address/0xF89C7b475821EC3fDC2dC8099032c05c6c0c9AB9)            |
 | Arbitrum       | [`0xff1a0f4744e8582DF1aE09D5611b887B6a12925C`](https://arbiscan.io/address/0xff1a0f4744e8582df1ae09d5611b887b6a12925c)                    |
-| Celo           | [`0xff1a0f4744e8582DF1aE09D5611b887B6a12925C`](https://celoscan.io/address/0xff1a0f4744e8582df1ae09d5611b887b6a12925c)                    |
-| KCC            | [`0xE0d0e68297772Dd5a1f1D99897c581E2082dbA5B`](https://explorer.kcc.io/en/address/0xe0d0e68297772dd5a1f1d99897c581e2082dba5b)             |
-| Cronos         | [`0xE0d0e68297772Dd5a1f1D99897c581E2082dbA5B`](https://cronoscan.com/address/0xe0d0e68297772dd5a1f1d99897c581e2082dba5b)                  |
-| zkSync Era     | [`0xf087c864AEccFb6A2Bf1Af6A0382B0d0f6c5D834`](https://explorer.zksync.io/address/0xf087c864AEccFb6A2Bf1Af6A0382B0d0f6c5D834)             |
-| EVMOS          | [`0x354bF866A4B006C9AF9d9e06d9364217A8616E12`](https://www.mintscan.io/evmos/evm/contract/0x354bF866A4B006C9AF9d9e06d9364217A8616E12)     |
-| Neon           | [`0x7f2dB085eFC3560AFF33865dD727225d91B4f9A5`](https://neonscan.org/address/0x7f2dB085eFC3560AFF33865dD727225d91B4f9A5)                   |
-| Polygon zkEVM  | [`0xC5E56d6b40F3e3B5fbfa266bCd35C37426537c65`](https://zkevm.polygonscan.com/address/0xc5e56d6b40f3e3b5fbfa266bcd35c37426537c65)          |
-| Meter          | [`0xbFe3f445653f2136b2FD1e6DdDb5676392E3AF16`](https://scan.meter.io/address/0xbfe3f445653f2136b2fd1e6dddb5676392e3af16)                  |
-| Conflux eSpace | [`0xe9d69CdD6Fe41e7B621B4A688C5D1a68cB5c8ADc`](https://evm.confluxscan.io/address/0xe9d69cdd6fe41e7b621b4a688c5d1a68cb5c8adc)             |
-| Canto          | [`0x98046Bd286715D3B0BC227Dd7a956b83D8978603`](https://www.mintscan.io/canto/evm/contract/0x98046Bd286715D3B0BC227Dd7a956b83D8978603)     |
-| Kava           | [`0xA2aa501b19aff244D90cc15a4Cf739D2725B5729`](https://explorer.kava.io/address/0xA2aa501b19aff244D90cc15a4Cf739D2725B5729)               |
-| Gnosis         | [`0x2880aB155794e7179c9eE2e38200202908C17B43`](https://gnosisscan.io/address/0x2880ab155794e7179c9ee2e38200202908c17b43)                  |
-| WEMIX          | [`0xA2aa501b19aff244D90cc15a4Cf739D2725B5729`](https://explorer.wemix.com/address/0xA2aa501b19aff244D90cc15a4Cf739D2725B5729)             |
-| Linea          | [`0xA2aa501b19aff244D90cc15a4Cf739D2725B5729`](https://explorer.linea.build/address/0xA2aa501b19aff244D90cc15a4Cf739D2725B5729)           |
-| Mantle         | [`0xA2aa501b19aff244D90cc15a4Cf739D2725B5729`](https://mantlescan.info/address/0xA2aa501b19aff244D90cc15a4Cf739D2725B5729)                |
-| EOS            | [`0xA2aa501b19aff244D90cc15a4Cf739D2725B5729`](https://explorer.evm.eosnetwork.com/address/0xA2aa501b19aff244D90cc15a4Cf739D2725B5729)    |
+| Aurora         | [`0xF89C7b475821EC3fDC2dC8099032c05c6c0c9AB9`](https://explorer.aurora.dev/address/0xF89C7b475821EC3fDC2dC8099032c05c6c0c9AB9)            |
+| Avalanche      | [`0x4305FB66699C3B2702D4d05CF36551390A4c69C6`](https://snowtrace.io/address/0x4305fb66699c3b2702d4d05cf36551390a4c69c6)                   |
+| BNB            | [`0x4D7E825f80bDf85e913E0DD2A2D54927e9dE1594`](https://bscscan.com/address/0x4d7e825f80bdf85e913e0dd2a2d54927e9de1594)                    |
 | Base           | [`0x8250f4aF4B972684F7b336503E2D6dFeDeB1487a`](https://basescan.org/address/0x8250f4aF4B972684F7b336503E2D6dFeDeB1487a)                   |
-| Ronin          | [`0x2880aB155794e7179c9eE2e38200202908C17B43`](https://app.roninchain.com/address/0x2880ab155794e7179c9ee2e38200202908c17b43)             |
-| Horizen EON    | [`0xA2aa501b19aff244D90cc15a4Cf739D2725B5729`](https://eon-explorer.horizenlabs.io/address/0xA2aa501b19aff244D90cc15a4Cf739D2725B5729)    |
 | Boba           | [`0x4374e5a8b9C22271E9EB878A2AA31DE97DF15DAF`](https://bobascan.com/address/0x4374e5a8b9C22271E9EB878A2AA31DE97DF15DAF)                   |
-| Shimmer        | [`0xA2aa501b19aff244D90cc15a4Cf739D2725B5729`](https://explorer.evm.shimmer.network/address/0xA2aa501b19aff244D90cc15a4Cf739D2725B5729)   |
-| Manta          | [`0xA2aa501b19aff244D90cc15a4Cf739D2725B5729`](https://pacific-explorer.manta.network/address/0xA2aa501b19aff244D90cc15a4Cf739D2725B5729) |
-| Scroll         | [`0xA2aa501b19aff244D90cc15a4Cf739D2725B5729`](https://blockscout.scroll.io/address/0xA2aa501b19aff244D90cc15a4Cf739D2725B5729)           |
+| Canto          | [`0x98046Bd286715D3B0BC227Dd7a956b83D8978603`](https://www.mintscan.io/canto/evm/contract/0x98046Bd286715D3B0BC227Dd7a956b83D8978603)     |
+| Celo           | [`0xff1a0f4744e8582DF1aE09D5611b887B6a12925C`](https://celoscan.io/address/0xff1a0f4744e8582df1ae09d5611b887b6a12925c)                    |
 | Chiliz         | [`0xA2aa501b19aff244D90cc15a4Cf739D2725B5729`](https://scan.chiliz.com/address/0xA2aa501b19aff244D90cc15a4Cf739D2725B5729)                |
+| Conflux eSpace | [`0xe9d69CdD6Fe41e7B621B4A688C5D1a68cB5c8ADc`](https://evm.confluxscan.io/address/0xe9d69cdd6fe41e7b621b4a688c5d1a68cb5c8adc)             |
 | Core DAO       | [`0xA2aa501b19aff244D90cc15a4Cf739D2725B5729`](https://scan.coredao.org/address/0xA2aa501b19aff244D90cc15a4Cf739D2725B5729)               |
+| Cronos         | [`0xE0d0e68297772Dd5a1f1D99897c581E2082dbA5B`](https://cronoscan.com/address/0xe0d0e68297772dd5a1f1d99897c581e2082dba5b)                  |
+| EOS            | [`0xA2aa501b19aff244D90cc15a4Cf739D2725B5729`](https://explorer.evm.eosnetwork.com/address/0xA2aa501b19aff244D90cc15a4Cf739D2725B5729)    |
+| EVMOS          | [`0x354bF866A4B006C9AF9d9e06d9364217A8616E12`](https://www.mintscan.io/evmos/evm/contract/0x354bF866A4B006C9AF9d9e06d9364217A8616E12)     |
+| Ethereum       | [`0x4305FB66699C3B2702D4d05CF36551390A4c69C6`](https://etherscan.io/address/0x4305fb66699c3b2702d4d05cf36551390a4c69c6)                   |
+| Fantom         | [`0xff1a0f4744e8582DF1aE09D5611b887B6a12925C`](https://ftmscan.com/address/0xff1a0f4744e8582df1ae09d5611b887b6a12925c)                    |
+| Gnosis         | [`0x2880aB155794e7179c9eE2e38200202908C17B43`](https://gnosisscan.io/address/0x2880ab155794e7179c9ee2e38200202908c17b43)                  |
+| Horizen EON    | [`0xA2aa501b19aff244D90cc15a4Cf739D2725B5729`](https://eon-explorer.horizenlabs.io/address/0xA2aa501b19aff244D90cc15a4Cf739D2725B5729)    |
+| KCC            | [`0xE0d0e68297772Dd5a1f1D99897c581E2082dbA5B`](https://explorer.kcc.io/en/address/0xe0d0e68297772dd5a1f1d99897c581e2082dba5b)             |
+| Kava           | [`0xA2aa501b19aff244D90cc15a4Cf739D2725B5729`](https://explorer.kava.io/address/0xA2aa501b19aff244D90cc15a4Cf739D2725B5729)               |
+| Linea          | [`0xA2aa501b19aff244D90cc15a4Cf739D2725B5729`](https://explorer.linea.build/address/0xA2aa501b19aff244D90cc15a4Cf739D2725B5729)           |
+| Manta          | [`0xA2aa501b19aff244D90cc15a4Cf739D2725B5729`](https://pacific-explorer.manta.network/address/0xA2aa501b19aff244D90cc15a4Cf739D2725B5729) |
+| Mantle         | [`0xA2aa501b19aff244D90cc15a4Cf739D2725B5729`](https://mantlescan.info/address/0xA2aa501b19aff244D90cc15a4Cf739D2725B5729)                |
+| Meter          | [`0xbFe3f445653f2136b2FD1e6DdDb5676392E3AF16`](https://scan.meter.io/address/0xbfe3f445653f2136b2fd1e6dddb5676392e3af16)                  |
+| Neon           | [`0x7f2dB085eFC3560AFF33865dD727225d91B4f9A5`](https://neonscan.org/address/0x7f2dB085eFC3560AFF33865dD727225d91B4f9A5)                   |
+| Optimism       | [`0xff1a0f4744e8582DF1aE09D5611b887B6a12925C`](https://optimistic.etherscan.io/address/0xff1a0f4744e8582df1ae09d5611b887b6a12925c)        |
+| Polygon        | [`0xff1a0f4744e8582DF1aE09D5611b887B6a12925C`](https://polygonscan.com/address/0xff1a0f4744e8582df1ae09d5611b887b6a12925c)                |
+| Polygon zkEVM  | [`0xC5E56d6b40F3e3B5fbfa266bCd35C37426537c65`](https://zkevm.polygonscan.com/address/0xc5e56d6b40f3e3b5fbfa266bcd35c37426537c65)          |
+| Ronin          | [`0x2880aB155794e7179c9eE2e38200202908C17B43`](https://app.roninchain.com/address/0x2880ab155794e7179c9ee2e38200202908c17b43)             |
+| Scroll         | [`0xA2aa501b19aff244D90cc15a4Cf739D2725B5729`](https://blockscout.scroll.io/address/0xA2aa501b19aff244D90cc15a4Cf739D2725B5729)           |
+| Shimmer        | [`0xA2aa501b19aff244D90cc15a4Cf739D2725B5729`](https://explorer.evm.shimmer.network/address/0xA2aa501b19aff244D90cc15a4Cf739D2725B5729)   |
 | Tomochain      | [`0xA2aa501b19aff244D90cc15a4Cf739D2725B5729`](https://tomoscan.io/address/0xA2aa501b19aff244D90cc15a4Cf739D2725B5729)                    |
+| WEMIX          | [`0xA2aa501b19aff244D90cc15a4Cf739D2725B5729`](https://explorer.wemix.com/address/0xA2aa501b19aff244D90cc15a4Cf739D2725B5729)             |
+| zkSync Era     | [`0xf087c864AEccFb6A2Bf1Af6A0382B0d0f6c5D834`](https://explorer.zksync.io/address/0xf087c864AEccFb6A2Bf1Af6A0382B0d0f6c5D834)             |
 
-### Beta
+## Testnets
 
 | Network                     | Contract address                                                                                                                                  |
 | --------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Goerli (Ethereum testnet)   | [`0xff1a0f4744e8582DF1aE09D5611b887B6a12925C`](https://goerli.etherscan.io/address/0xff1a0f4744e8582DF1aE09D5611b887B6a12925C)                    |
-| Sepolia (Ethereum testnet)  | [`0x2880aB155794e7179c9eE2e38200202908C17B43`](https://sepolia.etherscan.io/address/0x2880ab155794e7179c9ee2e38200202908c17b43)                   |
-| Fuji (Avalanche testnet)    | [`0xff1a0f4744e8582DF1aE09D5611b887B6a12925C`](https://testnet.snowtrace.io/address/0xff1a0f4744e8582DF1aE09D5611b887B6a12925C)                   |
-| Fantom testnet              | [`0xff1a0f4744e8582DF1aE09D5611b887B6a12925C`](https://testnet.ftmscan.com/address/0xff1a0f4744e8582df1ae09d5611b887b6a12925c)                    |
-| Mumbai (Polygon testnet)    | [`0xff1a0f4744e8582DF1aE09D5611b887B6a12925C`](https://mumbai.polygonscan.com/address/0xff1a0f4744e8582DF1aE09D5611b887B6a12925C)                 |
-| BNB testnet                 | [`0xd7308b14BF4008e7C7196eC35610B1427C5702EA`](https://testnet.bscscan.com/address/0xd7308b14BF4008e7C7196eC35610B1427C5702EA)                    |
-| Aurora testnet              | [`0x4305FB66699C3B2702D4d05CF36551390A4c69C6`](https://explorer.testnet.aurora.dev/address/0x4305FB66699C3B2702D4d05CF36551390A4c69C6)            |
-| Optimism Goerli (testnet)   | [`0xff1a0f4744e8582DF1aE09D5611b887B6a12925C`](https://goerli-optimism.etherscan.io/address/0xff1a0f4744e8582df1ae09d5611b887b6a12925c)           |
-| Optimism Sepolia (testnet)  | [`0x2880aB155794e7179c9eE2e38200202908C17B43`](https://optimism-sepolia.blockscout.com/address/0x2880aB155794e7179c9eE2e38200202908C17B43)        |
-| Celo Alfajores (testnet)    | [`0xff1a0f4744e8582DF1aE09D5611b887B6a12925C`](https://explorer.celo.org/alfajores/address/0xff1a0f4744e8582DF1aE09D5611b887B6a12925C)            |
-| KCC testnet                 | [`0x15D35b8985e350f783fe3d95401401E194ff1E6f`](https://scan-testnet.kcc.network/address/0x15D35b8985e350f783fe3d95401401E194ff1E6f)               |
-| Cronos testnet              | [`0xBAEA4A1A2Eaa4E9bb78f2303C213Da152933170E`](https://cronos.org/explorer/testnet3/address/0xBAEA4A1A2Eaa4E9bb78f2303C213Da152933170E)           |
-| Arbitrum Goerli (testnet)   | [`0x939C0e902FF5B3F7BA666Cc8F6aC75EE76d3f900`](https://goerli.arbiscan.io/address/0x939C0e902FF5B3F7BA666Cc8F6aC75EE76d3f900)                     |
-| Arbitrum Sepolia (testnet)  | [`0xA2aa501b19aff244D90cc15a4Cf739D2725B5729`](https://sepolia-explorer.arbitrum.io/address/0xA2aa501b19aff244D90cc15a4Cf739D2725B5729)           |
-| zkSync Era Goerli (testnet) | [`0xC38B1dd611889Abc95d4E0a472A667c3671c08DE`](https://goerli.explorer.zksync.io/address/0xC38B1dd611889Abc95d4E0a472A667c3671c08DE)              |
-| Base Goerli (testnet)       | [`0x5955C1478F0dAD753C7E2B4dD1b4bC530C64749f`](https://goerli.basescan.org/address/0x5955c1478f0dad753c7e2b4dd1b4bc530c64749f)                    |
-| Chiado (Gnosis testnet)     | [`0xdDAf6D29b8bc81c1F0798a5e4c264ae89c16a72B`](https://blockscout.com/gnosis/chiado/address/0xdDAf6D29b8bc81c1F0798a5e4c264ae89c16a72B)           |
-| EVMOS testnet               | [`0x354bF866A4B006C9AF9d9e06d9364217A8616E12`](https://evm.evmos.dev/address/0x354bF866A4B006C9AF9d9e06d9364217A8616E12)                          |
-| Neon devnet                 | [`0x2FF312f50689ad279ABb164dB255Eb568733BD6c`](https://devnet.neonscan.org/address/0x2FF312f50689ad279ABb164dB255Eb568733BD6c)                    |
-| Polygon zkEVM testnet       | [`0xd54bf1758b1C932F86B178F8b1D5d1A7e2F62C2E`](https://testnet-zkevm.polygonscan.com/address/0xd54bf1758b1c932f86b178f8b1d5d1a7e2f62c2e)          |
-| Canto testnet               | [`0xA2aa501b19aff244D90cc15a4Cf739D2725B5729`](https://testnet-explorer.canto.neobase.one/address/0xA2aa501b19aff244D90cc15a4Cf739D2725B5729)     |
-| Meter testnet               | [`0x5fF5B9039FbD8256864A4460B7EA77093A65B1b5`](https://scan-warringstakes.meter.io/address/0x5ff5b9039fbd8256864a4460b7ea77093a65b1b5)            |
-| Mantle testnet              | [`0xA2aa501b19aff244D90cc15a4Cf739D2725B5729`](https://testnet.mantlescan.org/address/0xa2aa501b19aff244d90cc15a4cf739d2725b5729)                 |
-| Conflux eSpace testnet      | [`0xA2aa501b19aff244D90cc15a4Cf739D2725B5729`](https://evmtestnet.confluxscan.io/address/0xa2aa501b19aff244d90cc15a4cf739d2725b5729)              |
-| Kava testnet                | [`0x98046Bd286715D3B0BC227Dd7a956b83D8978603`](https://explorer.testnet.kava.io/address/0x98046Bd286715D3B0BC227Dd7a956b83D8978603)               |
-| WEMIX testnet               | [`0xA2aa501b19aff244D90cc15a4Cf739D2725B5729`](https://explorer.test.wemix.com/address/0xA2aa501b19aff244D90cc15a4Cf739D2725B5729)                |
-| Linea Goerli                | [`0xA2aa501b19aff244D90cc15a4Cf739D2725B5729`](https://goerli.lineascan.build/address/0xA2aa501b19aff244D90cc15a4Cf739D2725B5729)                 |
-| EOS testnet                 | [`0xA2aa501b19aff244D90cc15a4Cf739D2725B5729`](https://explorer.testnet.evm.eosnetwork.com/address/0xA2aa501b19aff244D90cc15a4Cf739D2725B5729)    |
-| Shimmer testnet             | [`0xA2aa501b19aff244D90cc15a4Cf739D2725B5729`](https://explorer.evm.testnet.shimmer.network/address/0xA2aa501b19aff244D90cc15a4Cf739D2725B5729)   |
-| Scroll Sepolia              | [`0xA2aa501b19aff244D90cc15a4Cf739D2725B5729`](https://sepolia-blockscout.scroll.io/address/0xA2aa501b19aff244D90cc15a4Cf739D2725B5729)           |
-| Saigon (Ronin testnet)      | [`0xA2aa501b19aff244D90cc15a4Cf739D2725B5729`](https://saigon-app.roninchain.com/address/0xa2aa501b19aff244d90cc15a4cf739d2725b5729)              |
-| Horizen GOBI testnet        | [`0xA2aa501b19aff244D90cc15a4Cf739D2725B5729`](https://gobi-explorer.horizenlabs.io/address/0xA2aa501b19aff244D90cc15a4Cf739D2725B5729)           |
-| Boba Goerli (testnet)       | [`0xA2aa501b19aff244D90cc15a4Cf739D2725B5729`](https://testnet.bobascan.com/address/0xA2aa501b19aff244D90cc15a4Cf739D2725B5729)                   |
-| Manta testnet               | [`0xA2aa501b19aff244D90cc15a4Cf739D2725B5729`](https://pacific-explorer.testnet.manta.network/address/0xA2aa501b19aff244D90cc15a4Cf739D2725B5729) |
-| Chiliz testnet              | [`0xA2aa501b19aff244D90cc15a4Cf739D2725B5729`](https://spicy-explorer.chiliz.com/address/0xA2aa501b19aff244D90cc15a4Cf739D2725B5729)              |
-| Zetachain testnet           | [`0x87047526937246727E4869C5f76A347160e08672`](https://explorer.zetachain.com/address/0x87047526937246727E4869C5f76A347160e08672)                 |
-| Astar zkEVM testnet         | [`0xA2aa501b19aff244D90cc15a4Cf739D2725B5729`](https://zkatana.blockscout.com/address/0xA2aa501b19aff244D90cc15a4Cf739D2725B5729)                 |
-| Core DAO testnet            | [`0xA2aa501b19aff244D90cc15a4Cf739D2725B5729`](https://scan.test.btcs.network/address/0xa2aa501b19aff244d90cc15a4cf739d2725b5729)                 |
-| Tomochain testnet           | [`0x23f0e8FAeE7bbb405E7A7C3d60138FCfd43d7509`](https://testnet.tomoscan.io/address/0x23f0e8FAeE7bbb405E7A7C3d60138FCfd43d7509)                    |
+| Arbitrum Sepolia (testnet)  | [`0x4374e5a8b9C22271E9EB878A2AA31DE97DF15DAF`](https://sepolia-explorer.arbitrum.io/address/0x4374e5a8b9C22271E9EB878A2AA31DE97DF15DAF)           |
+| Astar zkEVM testnet         | [`0x8D254a21b3C86D32F7179855531CE99164721933`](https://zkatana.blockscout.com/address/0x8D254a21b3C86D32F7179855531CE99164721933)                 |
+| Aurora testnet              | [`0x74f09cb3c7e2A01865f424FD14F6dc9A14E3e94E`](https://explorer.testnet.aurora.dev/address/0x74f09cb3c7e2A01865f424FD14F6dc9A14E3e94E)            |
+| BNB testnet                 | [`0x5744Cbf430D99456a0A8771208b674F27f8EF0Fb`](https://testnet.bscscan.com/address/0x5744Cbf430D99456a0A8771208b674F27f8EF0Fb)                    |
+| Base Goerli (testnet)       | [`0xEbe57e8045F2F230872523bbff7374986E45C486`](https://goerli.basescan.org/address/0xEbe57e8045F2F230872523bbff7374986E45C486)                    |
+| Boba Goerli (testnet)       | [`0x8D254a21b3C86D32F7179855531CE99164721933`](https://testnet.bobascan.com/address/0x8D254a21b3C86D32F7179855531CE99164721933)                   |
+| Canto testnet               | [`0x26DD80569a8B23768A1d80869Ed7339e07595E85`](https://testnet-explorer.canto.neobase.one/address/0x26DD80569a8B23768A1d80869Ed7339e07595E85)     |
+| Celo Alfajores (testnet)    | [`0x74f09cb3c7e2A01865f424FD14F6dc9A14E3e94E`](https://explorer.celo.org/alfajores/address/0x74f09cb3c7e2A01865f424FD14F6dc9A14E3e94E)            |
+| Chiado (Gnosis testnet)     | [`0x98046Bd286715D3B0BC227Dd7a956b83D8978603`](https://blockscout.com/gnosis/chiado/address/0x98046Bd286715D3B0BC227Dd7a956b83D8978603)           |
+| Chiliz testnet              | [`0x23f0e8FAeE7bbb405E7A7C3d60138FCfd43d7509`](https://spicy-explorer.chiliz.com/address/0x23f0e8FAeE7bbb405E7A7C3d60138FCfd43d7509)              |
+| Conflux eSpace testnet      | [`0xDd24F84d36BF92C65F92307595335bdFab5Bbd21`](https://evmtestnet.confluxscan.io/address/0xDd24F84d36BF92C65F92307595335bdFab5Bbd21)              |
+| Core DAO testnet            | [`0x8D254a21b3C86D32F7179855531CE99164721933`](https://scan.test.btcs.network/address/0x8D254a21b3C86D32F7179855531CE99164721933)                 |
+| Cronos testnet              | [`0x36825bf3Fbdf5a29E2d5148bfe7Dcf7B5639e320`](https://cronos.org/explorer/testnet3/address/0x36825bf3Fbdf5a29E2d5148bfe7Dcf7B5639e320)           |
+| EOS testnet                 | [`0x0708325268dF9F66270F1401206434524814508b`](https://explorer.testnet.evm.eosnetwork.com/address/0x0708325268dF9F66270F1401206434524814508b)    |
+| EVMOS testnet               | [`0x74f09cb3c7e2A01865f424FD14F6dc9A14E3e94E`](https://evm.evmos.dev/address/0x74f09cb3c7e2A01865f424FD14F6dc9A14E3e94E)                          |
+| Fantom testnet              | [`0x5744Cbf430D99456a0A8771208b674F27f8EF0Fb`](https://testnet.ftmscan.com/address/0x5744Cbf430D99456a0A8771208b674F27f8EF0Fb)                    |
+| Fuji (Avalanche testnet)    | [`0x23f0e8FAeE7bbb405E7A7C3d60138FCfd43d7509`](https://testnet.snowtrace.io/address/0x23f0e8FAeE7bbb405E7A7C3d60138FCfd43d7509)                   |
+| KCC testnet                 | [`0x74f09cb3c7e2A01865f424FD14F6dc9A14E3e94E`](https://scan-testnet.kcc.network/address/0x74f09cb3c7e2A01865f424FD14F6dc9A14E3e94E)               |
+| Kava testnet                | [`0xfA25E653b44586dBbe27eE9d252192F0e4956683`](https://explorer.testnet.kava.io/address/0xfA25E653b44586dBbe27eE9d252192F0e4956683)               |
+| Linea Goerli                | [`0xdF21D137Aadc95588205586636710ca2890538d5`](https://goerli.lineascan.build/address/0xdF21D137Aadc95588205586636710ca2890538d5)                 |
+| Manta testnet               | [`0x41c9e39574F40Ad34c79f1C99B66A45eFB830d4c`](https://pacific-explorer.testnet.manta.network/address/0x41c9e39574F40Ad34c79f1C99B66A45eFB830d4c) |
+| Mantle testnet              | [`0xDd24F84d36BF92C65F92307595335bdFab5Bbd21`](https://testnet.mantlescan.org/address/0xDd24F84d36BF92C65F92307595335bdFab5Bbd21)                 |
+| Meter testnet               | [`0x5a71C07a0588074443545eE0c08fb0375564c3E4`](https://scan-warringstakes.meter.io/address/0x5a71C07a0588074443545eE0c08fb0375564c3E4)            |
+| Mumbai (Polygon testnet)    | [`0xFC6bd9F9f0c6481c6Af3A7Eb46b296A5B85ed379`](https://mumbai.polygonscan.com/address/0xFC6bd9F9f0c6481c6Af3A7Eb46b296A5B85ed379)                 |
+| Neon devnet                 | [`0x0708325268dF9F66270F1401206434524814508b`](https://devnet.neonscan.org/address/0x0708325268dF9F66270F1401206434524814508b)                    |
+| Optimism Goerli (testnet)   | [`0xDd24F84d36BF92C65F92307595335bdFab5Bbd21`](https://goerli-optimism.etherscan.io/address/0xDd24F84d36BF92C65F92307595335bdFab5Bbd21)           |
+| Polygon zkEVM testnet       | [`0xFf255f800044225f54Af4510332Aa3D67CC77635`](https://testnet-zkevm.polygonscan.com/address/0xFf255f800044225f54Af4510332Aa3D67CC77635)          |
+| Saigon (Ronin testnet)      | [`0xEbe57e8045F2F230872523bbff7374986E45C486`](https://saigon-app.roninchain.com/address/0xEbe57e8045F2F230872523bbff7374986E45C486)              |
+| Scroll Sepolia              | [`0x41c9e39574F40Ad34c79f1C99B66A45eFB830d4c`](https://sepolia-blockscout.scroll.io/address/0x41c9e39574F40Ad34c79f1C99B66A45eFB830d4c)           |
+| Sepolia (Ethereum testnet)  | [`0xDd24F84d36BF92C65F92307595335bdFab5Bbd21`](https://sepolia.etherscan.io/address/0xDd24F84d36BF92C65F92307595335bdFab5Bbd21)                   |
+| Shimmer testnet             | [`0x8D254a21b3C86D32F7179855531CE99164721933`](https://explorer.evm.testnet.shimmer.network/address/0x8D254a21b3C86D32F7179855531CE99164721933)   |
+| Tomochain testnet           | [`0x5D289Ad1CE59fCC25b6892e7A303dfFf3a9f7167`](https://testnet.tomoscan.io/address/0x5D289Ad1CE59fCC25b6892e7A303dfFf3a9f7167)                    |
+| WEMIX testnet               | [`0x26DD80569a8B23768A1d80869Ed7339e07595E85`](https://explorer.test.wemix.com/address/0x26DD80569a8B23768A1d80869Ed7339e07595E85)                |
+| Zetachain testnet           | [`0x0708325268dF9F66270F1401206434524814508b`](https://explorer.zetachain.com/address/0x0708325268dF9F66270F1401206434524814508b)                 |
+| zkSync Era Goerli (testnet) | [`0x8739d5024B5143278E2b15Bd9e7C26f6CEc658F1`](https://goerli.explorer.zksync.io/address/0x8739d5024B5143278E2b15Bd9e7C26f6CEc658F1)              |
+
+Pyth is available on the following networks using Pyth Beta data sources:
+
+| Network                    | Contract address                                                                                                                           |
+| -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| Horizen GOBI testnet       | [`0xA2aa501b19aff244D90cc15a4Cf739D2725B5729`](https://gobi-explorer.horizenlabs.io/address/0xA2aa501b19aff244D90cc15a4Cf739D2725B5729)    |
+| Optimism Sepolia (testnet) | [`0x2880aB155794e7179c9eE2e38200202908C17B43`](https://optimism-sepolia.blockscout.com/address/0x2880aB155794e7179c9eE2e38200202908C17B43) |
 
 ## Price Feed IDs
 
-The price feed IDs for EVM chains differs depending on whether they are a mainnet or testnet (see above):
-
-- [List of mainnet ids](https://pyth.network/developers/price-feed-ids#pyth-evm-mainnet)
-- [List of testnet ids](https://pyth.network/developers/price-feed-ids#pyth-evm-testnet)
+The price feed IDs for EVM chains are available [here](https://pyth.network/developers/price-feed-ids#pyth-evm-stable)


### PR DESCRIPTION
I am also sorting the list.