### PR TITLE
pages: Add weekly-schedule-format, link to it in product-metadata

### DIFF
--- a/pages/documentation/how-pyth-works/_meta.json
+++ b/pages/documentation/how-pyth-works/_meta.json
@@ -5,5 +5,6 @@
   "account-structure": "Account Structure",
   "product-metadata": "Product Metadata",
   "price-aggregation": "Price Aggregation",
-  "ema-price-aggregation": "EMA Price Aggregation"
+  "ema-price-aggregation": "EMA Price Aggregation",
+  "weekly-schedule-format": "Weekly Schedule Format"
 }

--- a/pages/documentation/how-pyth-works/product-metadata.mdx
+++ b/pages/documentation/how-pyth-works/product-metadata.mdx
@@ -102,6 +102,10 @@ product_account .. eAnmHaCS2J1XPEb6zohWFrnXD3Mni3wTrfKGhkoQmcZ
   price_account .. H6dt83FavYgfJR8oV7HewKWZjzveFFiDhq41VbmDYnVF
 ```
 
+**Other Fields**
+
+- `weekly_schedule` - Optional field. When set, contents are used by publishers to learn about a symbol's typical market hours. See [Weekly Schedule Format](weekly-schedule-format) for a detailed format specification.
+
 **Best Practices**
 
 The users should not rely on the symbol name being unchanging or parse data out of the symbol.

--- a/pages/documentation/how-pyth-works/weekly-schedule-format.mdx
+++ b/pages/documentation/how-pyth-works/weekly-schedule-format.mdx
@@ -1,0 +1,37 @@
+# Pyth Oracle Weekly Schedule Format, version 1
+
+This document outlines the rules for specifying contents of a new Pyth product metadata field - `weekly_schedule` . The field specifies the recurring weekly schedule of a product’s market hours. It serves as a reference for `pyth-agent` to stop publishing outside the hours specified in the schedule. Notable use cases include:
+
+- FX
+- Metals
+- Stocks
+
+## The format
+
+```plain
+Timezone,MHKind,MHKind,MHKind,MHKind,MHKind,MHKind,MHKind
+```
+
+**Note: None of the comma-separated values can be ommitted - exactly one timezone and seven subsequent per-day schedules are required. That said, ommitting `weekly_schedule` on a symbol is allowed and will cause pyth-agent to default to 24/7 publishing (the usual behavior before this feature)**
+
+**Detailed Definitions**
+
+- `Timezone` - A human-readable tz database TZ identifier of the market’s local timezone - e.g. `America/New_York`. **Full list of identifiers can be found [here](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones)**. Notes:
+  - Daylight-saving time - Handled automatically by pyth-agent code dealing with the format.
+- `MHKind` - A single week day’s schedule. The `MHKind` values describe week days from Monday to Sunday, in that order. `MHKind` is defined as one of:
+  - `O` - all-day open
+  - `C` - all-day closed
+  - `Hour:Minute-Hour:Minute` - specific open and close times in the market-local timezone. Open time must come before close time. **The range is inclusive.** Definitions:
+    - `Hour` - number of hours from `00` to `24` . Notes:
+      - Leading zeros are optional - e.g. `9` and `09`, `0` and `00` are equivalent.
+      - `24` can only be used to specify `24:00`. This value is used to express the final moment of a given day (split-second before `00:00` on the next day). Context: Without this special case, the next best thing would be `23:59` which could cause a symbol to go down between `23:59` and the next day’s `00:00` for a full minute.
+    - `Minute` - number of minutes from `00` to `59`. Notes:
+      - Leading zeros are **mandatory** - e.g. `9:05`, `9:00`, `15:07`
+
+**Examples**
+
+- `Europe/Lisbon,O,O,O,O,O,C,C` - 24h open from Monday to Friday, according to Lisbon’s perspective of midnight. Closed on Saturdays and Sundays.
+- `America/New_York,9:30-16:30,9:30-16:30,9:30-16:30,9:30-16:30,9:30-16:30,C,C` - Open 9:30AM - 4:30PM ET (EDT or EST) from Monday to Friday. Closed outside specified ranges, on Saturdays and on Sundays. Based off real-life NASDAQ hours.
+- `Israel,9:59-17:14,9:59-17:14,9:59-17:14,9:59-17:14,C,C,9:59-15:39` - Interesting edge case of the Tel-Aviv Stock Exchange. Open with reduced hours on Sundays, closed on Friday and Saturday. Note the slash-less timezone name.
+- `Africa/Johannesburg,C,C,C,C,C,C,C` - Trivial made-up example. The market is not trading on any day - exact opposite of 24/7 trading. Pyth-agent instances observing this value will not publish the product at any time. Note: The timezone has no effect in this case.
+- `Europe/London,O,O,O,O,O,O,O` - Trivial example. The market is open at all times and the timezone has no effect. Equivalent to default 24/7 behavior when `weekly_schedule` is not specified on a symbol.


### PR DESCRIPTION
This change adds the weekly schedule format spec, basing off the Notion doc shared internally earlier and links to it in the `product-metadata` page.

# Review Highlights
* `product-metadata` - There's some existing mentions of market hours there, I _think_ they still make sense, but it would be good to make sure.