### PR TITLE
Update the EVM how-to guide

### DIFF
--- a/pages/price-feeds/use-real-time-data/evm.mdx
+++ b/pages/price-feeds/use-real-time-data/evm.mdx
@@ -2,27 +2,163 @@
 description: Consume Pyth Network prices in EVM applications
 ---
 
-# Pyth on EVM
+# How to Use Real-Time Data in EVM Contracts
 
-On-chain EVM programs can use the [Solidity SDK](https://github.com/pyth-network/pyth-crosschain/tree/main/target_chains/ethereum/sdk/solidity) to read Pyth prices.
-The [EVM API reference](../api-reference/evm) lets you interactively explore the complete API of the Pyth contract.
+This guide explains how to use real-time Pyth data in EVM contracts.
 
-The off-chain portion of the application can use [pyth-evm-js](https://github.com/pyth-network/pyth-crosschain/tree/main/target_chains/ethereum/sdk/js) to generate price update transactions.
+## Install Pyth SDKs
 
-Then follow the [Quickstart](https://github.com/pyth-network/pyth-crosschain/tree/main/target_chains/ethereum/sdk/js#quickstart) guide, which includes an example of both the on- and off-chain code necessary to integrate with Pyth.
+Pyth provides two SDKs for the on- and off-chain portions of the integration.
+
+### Solidity SDK
+
+Add the [Pyth Price Feeds Solidity SDK](https://github.com/pyth-network/pyth-crosschain/tree/main/target_chains/ethereum/sdk/solidity) to the dependencies of your EVM contract.
+This SDK provides the `IPyth` interface for working with the Pyth Price Feeds Contract.
+
+**Truffle/Hardhat**
+
+If you are using Truffle or Hardhat, simply install the NPM package:
+
+```bash
+npm install @pythnetwork/pyth-sdk-solidity
+```
+
+**Foundry**
+
+If you are using Foundry, you will need to create an NPM project if you don't already have one.
+From the root directory of your project, run:
+
+```bash
+npm init -y
+npm install @pythnetwork/pyth-sdk-solidity
+```
+
+Then add the following line to your `remappings.txt` file:
+
+```text
+@pythnetwork/pyth-sdk-solidity/=node_modules/@pythnetwork/pyth-sdk-solidity
+```
+
+### Typescript SDK
+
+Add [pyth-evm-js](https://github.com/pyth-network/pyth-crosschain/tree/main/target_chains/ethereum/sdk/js) to your off-chain dependencies.
+
+```bash copy
+npm install --save @pythnetwork/pyth-evm-js
+```
+
+## Gather Resources
+
+To use the Pyth SDK, you need the address of a Pyth Price Feeds contract on your blockchain.
+Consult the current [Price Feeds Contract Addresses on EVM](../contract-addresses/evm) to find the address on your chain.
+Note that some testnet chains have two separate contract deployments for the two data channels: Stable and Beta.
+Most users should select the Stable channel, which provides the most reliable data.
+
+You will also need the IDs of the price feeds you wish to use.
+Consult the [Price Feed IDs](https://pyth.network/developers/price-feed-ids) reference to find these IDs.
+Note that the IDs differ between the Stable and Beta channels, so please choose the correct ID for your selected channel.
+
+Finally, you will also need the URL of a [Hermes](../api-instances-and-providers/hermes) instance.
+Consult the linked guide to find an instance.
+The Pyth Data Association operates two public Hermes endpoints for development purposes.
+Please select the same channel -- likely Stable -- for Hermes that you chose for the other resources.
+
+## Write Contract Code
+
+Add code to your contract to update and read the Pyth price.
+Your contract should do the following four steps:
+
+1. Instantiate the `IPyth` interface from the Solidity SDK using the price feeds contract address.
+1. Call `IPyth.getUpdateFee` to calculate the fee charged by Pyth to update the price.
+1. Call `IPyth.updatePriceFeeds` to update the price.
+1. Call `IPyth.getPrice` to read the current price, providing the price feed ID that you wish to read.
+
+Steps (2) and (3) both require a `bytes[] calldata priceUpdateData` argument that will be provided from off-chain.
+Simply add this argument to the functions on your contract that need it.
+
+The code snippet below provides a general template for what your contract code should look like:
+
+```solidity
+pragma solidity ^0.8.0;
+
+import "@pythnetwork/pyth-sdk-solidity/IPyth.sol";
+import "@pythnetwork/pyth-sdk-solidity/PythStructs.sol";
+
+contract SomeContract {
+  IPyth pyth;
+
+  constructor(address pythContract) {
+    pyth = IPyth(pythContract);
+  }
+
+  function doSomething(
+    uint someArg,
+    string memory otherArg,
+    bytes[] calldata priceUpdateData
+  ) public payable {
+    // Update the on-chain Pyth price(s)
+    uint fee = pyth.getUpdateFee(priceUpdateData);
+    pyth.updatePriceFeeds{ value: fee }(priceUpdateData);
+
+    // Read the current price
+    bytes32 priceId = 0xf9c0172ba10dfa4d19088d94f5bf61d3b54d5bd7483a322a982e1373ee8ea31b;
+    PythStructs.Price price = pyth.getPrice(priceId);
+  }
+}
+
+```
+
+## Write Frontend Code
+
+Add frontend code to query price update data from Hermes and pass it to your contract.
+Your frontend code should do the following things:
+
+1. Instantiate an `EvmPriceServiceConnection` pointing to your Hermes instance.
+1. Get price update data using this connection -- you can either perform one-off queries for this using `getPriceFeedsUpdateData` or subscribe for real-time updates via websocket.
+1. Optionally get the Pyth fee required to perform the price update.
+   You will need to do this step if your app is passing Pyth fees on to end users.
+1. Pass the price update data to your contract.
+   If you are passing along pyth fees, you will additionally need to provide the `value` parameter with the fee from the previous step.
+
+```typescript copy
+import { EvmPriceServiceConnection } from "@pythnetwork/pyth-evm-js";
+
+async function run() {
+  const connection = new EvmPriceServiceConnection("https://hermes.pyth.network");
+  const priceIds = ["fill this in with your ids"]
+  const priceFeedUpdateData = await connection.getPriceFeedsUpdateData(
+    priceIds
+  );
+
+  // If necessary, you can collect the price update fee from the pythContract.
+  //
+  // `pythContract` below is a web3.js contract; if you wish to use ethers, you need to change it accordingly.
+  // You can find the Pyth interface ABI in @pythnetwork/pyth-sdk-solidity npm package.
+  const pythContract = ...;
+  const updateFee = await pythContract.methods
+    .getUpdateFee(priceFeedUpdateData)
+    .call();
+
+  // Pass the update data to your contract.
+  // `someContract` below is a web3.js contract; if you wish to use ethers, you need to change it accordingly.
+  const someContract = ...;
+  await someContract.methods
+    .doSomething(someArg, otherArg, priceFeedUpdateData)
+    .send({ value: updateFee });
+}
+
+run();
+```
 
 ## Additional Resources
 
-### Contract Addresses
+You may find these additional resources helpful for developing your EVM application.
 
-Developers will need the address of the Pyth price feed contract on their blockchain in order to use Pyth.
-Please consult [EVM Contract Addresses](../contract-addresses/evm) to find the address for your blockchain.
+### API Reference
 
-### Price Feed IDs
+The [EVM API reference](../../evm) lets you interactively explore the complete API of the Pyth contract.
 
-Consult the [Price Feed IDs](https://pyth.network/developers/price-feed-ids) reference to find the IDs of the price feeds you wish to use.
-
-### Example Application
+### Example Applications
 
 [Oracle Swap](https://github.com/pyth-network/pyth-crosschain/tree/main/target_chains/ethereum/examples/oracle_swap) is an end-to-end example application that uses Pyth Network price feeds.
 This application is an AMM that allows users to swap two assets at the Pyth-provided exchange rate. The example contains both the contract and a frontend to interact with it.


### PR DESCRIPTION
I'm trying to update the EVM docs to work as a how-to guide, meaning there are specific steps that you can follow to use real-time pyth data.

Please LMK what you think of the new format. We can fine-tune it here and then propagate to other parts of the docs.