### PR TITLE
Remove legacy addresses from sui

### DIFF
--- a/pages/price-feeds/contract-addresses/sui.mdx
+++ b/pages/price-feeds/contract-addresses/sui.mdx
@@ -17,23 +17,3 @@
 | Pyth Package ID     | [`0xf7114cc10266d90c0c9e4b84455bddf29b40bd78fe56832c7ac98682c3daa95b`](https://explorer.sui.io/object/0xf7114cc10266d90c0c9e4b84455bddf29b40bd78fe56832c7ac98682c3daa95b?network=testnet) |
 | Wormhole State ID   | [`0xebba4cc4d614f7a7cdbe883acc76d1cc767922bc96778e7b68be0d15fce27c02`](https://explorer.sui.io/object/0xebba4cc4d614f7a7cdbe883acc76d1cc767922bc96778e7b68be0d15fce27c02?network=testnet) |
 | Wormhole Package ID | [`0xcc029e2810f17f9f43f52262f40026a71fbdca40ed3803ad2884994361910b7e`](https://explorer.sui.io/object/0xcc029e2810f17f9f43f52262f40026a71fbdca40ed3803ad2884994361910b7e?network=testnet) |
-
-## Legacy Addresses
-
-### Mainnet
-
-| Name                | Address                                                                                                                                                                   |
-| ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Pyth State ID       | [`0xf9ff3ef935ef6cdfb659a203bf2754cebeb63346e29114a535ea6f41315e5a3f`](https://explorer.sui.io/object/0xf9ff3ef935ef6cdfb659a203bf2754cebeb63346e29114a535ea6f41315e5a3f) |
-| Pyth Package ID     | [`0x00b53b0f4174108627fbee72e2498b58d6a2714cded53fac537034c220d26302`](https://explorer.sui.io/object/0x00b53b0f4174108627fbee72e2498b58d6a2714cded53fac537034c220d26302) |
-| Wormhole State ID   | [`0xaeab97f96cf9877fee2883315d459552b2b921edc16d7ceac6eab944dd88919c`](https://explorer.sui.io/object/0xaeab97f96cf9877fee2883315d459552b2b921edc16d7ceac6eab944dd88919c) |
-| Wormhole Package ID | [`0x5306f64e312b581766351c07af79c72fcb1cd25147157fdc2f8ad76de9a3fb6a`](https://explorer.sui.io/object/0x5306f64e312b581766351c07af79c72fcb1cd25147157fdc2f8ad76de9a3fb6a) |
-
-### Testnet
-
-| Name                | Address                                                                                                                                                                                   |
-| ------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Pyth State ID       | [`0xd8afde3a48b4ff7212bd6829a150f43f59043221200d63504d981f62bff2e27a`](https://explorer.sui.io/object/0xd8afde3a48b4ff7212bd6829a150f43f59043221200d63504d981f62bff2e27a?network=testnet) |
-| Pyth Package ID     | [`0x975e063f398f720af4f33ec06a927f14ea76ca24f7f8dd544aa62ab9d5d15f44`](https://explorer.sui.io/object/0x975e063f398f720af4f33ec06a927f14ea76ca24f7f8dd544aa62ab9d5d15f44?network=testnet) |
-| Wormhole State ID   | [`0xebba4cc4d614f7a7cdbe883acc76d1cc767922bc96778e7b68be0d15fce27c02`](https://explorer.sui.io/object/0xebba4cc4d614f7a7cdbe883acc76d1cc767922bc96778e7b68be0d15fce27c02?network=testnet) |
-| Wormhole Package ID | [`0xcc029e2810f17f9f43f52262f40026a71fbdca40ed3803ad2884994361910b7e`](https://explorer.sui.io/object/0xcc029e2810f17f9f43f52262f40026a71fbdca40ed3803ad2884994361910b7e?network=testnet) |


### PR DESCRIPTION
Since the old attesters are shut down, nobody can update the prices for these packages rendering them useless