### PR TITLE
Revert "hermes: remove self-host guide"

### DIFF
--- a/pages/price-feeds/api-instances-and-providers/_meta.json
+++ b/pages/price-feeds/api-instances-and-providers/_meta.json
@@ -1,3 +1,4 @@
 {
-  "hermes": "Hermes"
+  "hermes": "Hermes",
+  "pythnet-rpc": "Pythnet RPC"
 }

--- a/pages/price-feeds/api-instances-and-providers/hermes.mdx
+++ b/pages/price-feeds/api-instances-and-providers/hermes.mdx
@@ -20,3 +20,10 @@ The following node providers offer Hermes:
 - [Triton](https://triton.one)
 - [P2P](https://p2p.org)
 - [extrnode](https://extrnode.com/)
+
+## Self-Hosting
+
+We provide a Helm chart for running Hermes in our
+[charts](https://github.com/pyth-network/charts/tree/main/charts/hermes) repository. Please refer to the chart's readme
+for the configuration values.
+You will need a Pythnet RPC to run Hermes; see the [guide for accessing a Pythnet RPC](pythnet-rpc).

--- a/pages/price-feeds/api-instances-and-providers/pythnet-rpc.mdx
+++ b/pages/price-feeds/api-instances-and-providers/pythnet-rpc.mdx
@@ -1,0 +1,12 @@
+# Pythnet RPC
+
+You will need a Pythnet RPC to run Hermes, which you can obtain from any of the Pythnet RPC
+providers below:
+
+- [Triton](https://triton.one)
+- [P2P](https://p2p.org)
+- [Blockdaemon](https://blockdaemon.com/)
+- [Figment](https://figment.io)
+
+Alternatively, you can host Pythnet RPC yourself, but this is discouraged due to the potential high cost and maintenance
+involved in operating it. If you still wish to run it, please contact the Pyth team for more information.


### PR DESCRIPTION
Reverts pyth-network/documentation#164