### PR TITLE
Fix relative links

### DIFF
--- a/pages/home/_meta.json
+++ b/pages/home/_meta.json
@@ -8,17 +8,17 @@
 
   "Price Feeds": {
     "title": "Price Feeds →",
-    "href": "../price-feeds"
+    "href": "/price-feeds"
   },
 
   "Benchmarks": {
     "title": "Benchmarks →",
-    "href": "../benchmarks"
+    "href": "/benchmarks"
   },
 
   "Entropy": {
     "title": "Entropy →",
-    "href": "../entropy"
+    "href": "/entropy"
   },
 
   "--- Additional Information": {


### PR DESCRIPTION
The relative links break if you're on a nested page within the index (try clicking them from PYTH token distribution page  here https://docs.pyth.network/home/pyth-token/pyth-distribution )