### PR TITLE
Hide bottom nav links

### DIFF
--- a/theme.config.tsx
+++ b/theme.config.tsx
@@ -22,6 +22,7 @@ const config: DocsThemeConfig = {
   sidebar: {
     defaultMenuCollapseLevel: 1,
   },
+  navigation: false,
   useNextSeoProps() {
     return {
       titleTemplate: "%s – Pyth Network Documentation",


### PR DESCRIPTION
Remove the navigation links to the next/previous page that show up at the bottom of each docs page. these don't work nicely with the "link" entries in the table of contents on the left, and they're not that useful anyway.