### PR TITLE
Add pythnet contract addresses

### DIFF
--- a/pages/price-feeds/contract-addresses/_meta.json
+++ b/pages/price-feeds/contract-addresses/_meta.json
@@ -4,5 +4,6 @@
   "aptos": "Aptos",
   "sui": "Sui",
   "cosmwasm": "CosmWasm",
-  "near": "NEAR"
+  "near": "NEAR",
+  "pythnet": "Pythnet"
 }

--- a/pages/price-feeds/contract-addresses/pythnet.mdx
+++ b/pages/price-feeds/contract-addresses/pythnet.mdx
@@ -1,0 +1,15 @@
+# Price Feed Program Addresses on Pythnet
+
+The following table contains the addresses of the programs deployed on Pythnet that operate together to construct Pyth prices and deliver them to other blockchains:
+
+| Network  | Program                                                                                                 | Program address                                |
+| -------- | ------------------------------------------------------------------------------------------------------- | ---------------------------------------------- |
+| Pythnet  | [Oracle Program](https://github.com/pyth-network/pyth-client/tree/main)                                 | `FsJ3A3u2vn5cTVofAjvy6y5kwABJAqYWpe4975bi2epH` |
+| Pythnet  | [Remote Executor](https://github.com/pyth-network/pyth-crosschain/tree/main/governance/remote_executor) | `exe6S3AxPVNmy46L4Nj6HrnnAVQUhwyYzMSNcnRn3qq`  |
+| Pythnet  | [Message Buffer](https://github.com/pyth-network/pyth-crosschain/tree/main/pythnet/message_buffer)      | `7Vbmv1jt4vyuqBZcpYPpnVhrqVe5e6ZPb6JxDcffRHUM` |
+| Pythtest | [Oracle Program](https://github.com/pyth-network/pyth-client/tree/main)                                 | `gSbePebfvPy7tRqimPoVecS2UsBvYv46ynrzWocc92s`  |
+| Pythtest | [Oracle Program](https://github.com/pyth-network/pyth-client/tree/main)                                 | `8tfDNiaEyrV6Q1U4DEXrEigs9DoDtkugzFbybENEbCDz` |
+| Pythtest | [Remote Executor](https://github.com/pyth-network/pyth-crosschain/tree/main/governance/remote_executor) | `exe6S3AxPVNmy46L4Nj6HrnnAVQUhwyYzMSNcnRn3qq`  |
+| Pythtest | [Message Buffer](https://github.com/pyth-network/pyth-crosschain/tree/main/pythnet/message_buffer)      | `7Vbmv1jt4vyuqBZcpYPpnVhrqVe5e6ZPb6JxDcffRHUM` |
+
+Note that Pythnet above is the mainnet network for Pyth, and Pythtest is a testnet for development purposes.


### PR DESCRIPTION
I want to have a public reference for pythnet contracts for our bug bounty program, and it's a good idea regardless. 

I think we probably still need to create a section with governance and staking program addresses, but we don't have a good spot for that in the docs right now, so will circle back.

Please feel free to merge if you are happy with the change.