### PR TITLE
Solana push docs

### DIFF
--- a/pages/price-feeds/_meta.json
+++ b/pages/price-feeds/_meta.json
@@ -32,6 +32,7 @@
   },
 
   "price-feed-ids": "Price Feed IDs",
+  "sponsored-feeds": "Sponsored Feeds",
   "market-hours": "Market Hours",
   "best-practices": "Best Practices",
   "api-reference": "API Reference",

--- a/pages/price-feeds/contract-addresses/solana.mdx
+++ b/pages/price-feeds/contract-addresses/solana.mdx
@@ -1,6 +1,31 @@
 import CopyAddress from "../../../components/CopyAddress";
 
-# Price Feed Program Addresses on Solana
+# Program Addresses on Solana
+
+Pyth has two different versions of the oracle program on Solana.
+
+## Pull Oracle
+
+The Pyth pull oracle consists of two different programs.
+The Solana receiver program is deployed at the following addresses:
+
+| Network        | Program address                                                                                                                                                               |
+| -------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Solana Mainnet | <CopyAddress address={`rec5EKMGg6MxZYaMdyBfgwp4d5rB9T1VQH5pJv5LtFJ`} url="https://explorer.solana.com/address/rec5EKMGg6MxZYaMdyBfgwp4d5rB9T1VQH5pJv5LtFJ" />                 |
+| Solana Devnet  | <CopyAddress address={`rec5EKMGg6MxZYaMdyBfgwp4d5rB9T1VQH5pJv5LtFJ`} url="https://explorer.solana.com/address/rec5EKMGg6MxZYaMdyBfgwp4d5rB9T1VQH5pJv5LtFJ?cluster=devnet" />  |
+| Solana Testnet | <CopyAddress address={`rec5EKMGg6MxZYaMdyBfgwp4d5rB9T1VQH5pJv5LtFJ`} url="https://explorer.solana.com/address/rec5EKMGg6MxZYaMdyBfgwp4d5rB9T1VQH5pJv5LtFJ?cluster=testnet" /> |
+
+The price feed program is deployed at the following addresses:
+
+| Network        | Program address                                                                                                                                                               |
+| -------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Solana Mainnet | <CopyAddress address={`pythWSnswVUd12oZpeFP8e9CVaEqJg25g1Vtc2biRsT`} url="https://explorer.solana.com/address/pythWSnswVUd12oZpeFP8e9CVaEqJg25g1Vtc2biRsT" />                 |
+| Solana Devnet  | <CopyAddress address={`pythWSnswVUd12oZpeFP8e9CVaEqJg25g1Vtc2biRsT`} url="https://explorer.solana.com/address/pythWSnswVUd12oZpeFP8e9CVaEqJg25g1Vtc2biRsT?cluster=devnet" />  |
+| Solana Testnet | <CopyAddress address={`pythWSnswVUd12oZpeFP8e9CVaEqJg25g1Vtc2biRsT`} url="https://explorer.solana.com/address/pythWSnswVUd12oZpeFP8e9CVaEqJg25g1Vtc2biRsT?cluster=testnet" /> |
+
+## Legacy Oracle
+
+The table below lists the address of the previous version of the Pyth oracle program:
 
 | Network        | Program address                                                                                                                                                                 |
 | -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |

--- a/pages/price-feeds/contract-addresses/solana.mdx
+++ b/pages/price-feeds/contract-addresses/solana.mdx
@@ -9,19 +9,17 @@ Pyth has two different versions of the oracle program on Solana.
 The Pyth pull oracle consists of two different programs.
 The Solana receiver program is deployed at the following addresses:
 
-| Network        | Program address                                                                                                                                                               |
-| -------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Solana Mainnet | <CopyAddress address={`rec5EKMGg6MxZYaMdyBfgwp4d5rB9T1VQH5pJv5LtFJ`} url="https://explorer.solana.com/address/rec5EKMGg6MxZYaMdyBfgwp4d5rB9T1VQH5pJv5LtFJ" />                 |
-| Solana Devnet  | <CopyAddress address={`rec5EKMGg6MxZYaMdyBfgwp4d5rB9T1VQH5pJv5LtFJ`} url="https://explorer.solana.com/address/rec5EKMGg6MxZYaMdyBfgwp4d5rB9T1VQH5pJv5LtFJ?cluster=devnet" />  |
-| Solana Testnet | <CopyAddress address={`rec5EKMGg6MxZYaMdyBfgwp4d5rB9T1VQH5pJv5LtFJ`} url="https://explorer.solana.com/address/rec5EKMGg6MxZYaMdyBfgwp4d5rB9T1VQH5pJv5LtFJ?cluster=testnet" /> |
+| Network        | Program address                                                                                                                                                              |
+| -------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Solana Mainnet | <CopyAddress address={`rec5EKMGg6MxZYaMdyBfgwp4d5rB9T1VQH5pJv5LtFJ`} url="https://explorer.solana.com/address/rec5EKMGg6MxZYaMdyBfgwp4d5rB9T1VQH5pJv5LtFJ" />                |
+| Solana Devnet  | <CopyAddress address={`rec5EKMGg6MxZYaMdyBfgwp4d5rB9T1VQH5pJv5LtFJ`} url="https://explorer.solana.com/address/rec5EKMGg6MxZYaMdyBfgwp4d5rB9T1VQH5pJv5LtFJ?cluster=devnet" /> |
 
 The price feed program is deployed at the following addresses:
 
-| Network        | Program address                                                                                                                                                               |
-| -------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Solana Mainnet | <CopyAddress address={`pythWSnswVUd12oZpeFP8e9CVaEqJg25g1Vtc2biRsT`} url="https://explorer.solana.com/address/pythWSnswVUd12oZpeFP8e9CVaEqJg25g1Vtc2biRsT" />                 |
-| Solana Devnet  | <CopyAddress address={`pythWSnswVUd12oZpeFP8e9CVaEqJg25g1Vtc2biRsT`} url="https://explorer.solana.com/address/pythWSnswVUd12oZpeFP8e9CVaEqJg25g1Vtc2biRsT?cluster=devnet" />  |
-| Solana Testnet | <CopyAddress address={`pythWSnswVUd12oZpeFP8e9CVaEqJg25g1Vtc2biRsT`} url="https://explorer.solana.com/address/pythWSnswVUd12oZpeFP8e9CVaEqJg25g1Vtc2biRsT?cluster=testnet" /> |
+| Network        | Program address                                                                                                                                                              |
+| -------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Solana Mainnet | <CopyAddress address={`pythWSnswVUd12oZpeFP8e9CVaEqJg25g1Vtc2biRsT`} url="https://explorer.solana.com/address/pythWSnswVUd12oZpeFP8e9CVaEqJg25g1Vtc2biRsT" />                |
+| Solana Devnet  | <CopyAddress address={`pythWSnswVUd12oZpeFP8e9CVaEqJg25g1Vtc2biRsT`} url="https://explorer.solana.com/address/pythWSnswVUd12oZpeFP8e9CVaEqJg25g1Vtc2biRsT?cluster=devnet" /> |
 
 ## Legacy Oracle
 

--- a/pages/price-feeds/price-feed-ids.mdx
+++ b/pages/price-feeds/price-feed-ids.mdx
@@ -12,5 +12,6 @@ To use a price feed on-chain, look up its ID using these page, then store the fe
 
 ## Solana Price Feed Accounts
 
-For Solana price feeds, each price feed id is also the id of a Solana account containing the feed's data.
-Once you have the ID of your desired feed, you should pass the corresponding Solana account to any instruction that requires the current price and validate in your program that the account key matches the stored price feed id.
+On Solana, each feed additionally has a collection of **price feed accounts** containing the feed's data.
+The addresses of these accounts are programmatically derived from the feed id and a shard id, which is simply a number ranging from 0 to 255.
+See [How to Use Real-Time Data on Solana](price-feeds/use-real-time-data/solana#write-frontend-code) for more information on price feed accounts.

--- a/pages/price-feeds/price-feed-ids.mdx
+++ b/pages/price-feeds/price-feed-ids.mdx
@@ -13,5 +13,5 @@ To use a price feed on-chain, look up its ID using these page, then store the fe
 ## Solana Price Feed Accounts
 
 On Solana, each feed additionally has a collection of **price feed accounts** containing the feed's data.
-The addresses of these accounts are programmatically derived from the feed id and a shard id, which is simply a number ranging from 0 to 255.
+The addresses of these accounts are programmatically derived from the feed id and a shard id, which is simply a 16-bit number.
 See [How to Use Real-Time Data on Solana](price-feeds/use-real-time-data/solana#write-frontend-code) for more information on price feed accounts.

--- a/pages/price-feeds/sponsored-feeds.mdx
+++ b/pages/price-feeds/sponsored-feeds.mdx
@@ -1,0 +1,26 @@
+# Sponsored Feeds
+
+The Pyth Data Association sponsors price updates for several price feeds in Solana mainnet and devnet.
+The accounts listed in the table below are shard 0 for the relevant price feed id:
+
+| Name        | Account Address                                | Price Feed Id                                                      |
+| ----------- | ---------------------------------------------- | ------------------------------------------------------------------ |
+| SOL/USD     | `7UVimffxr9ow1uXYxsr4LHAcV58mLzhmwaeKvJ1pjLiE` | `ef0d8b6fda2ceba41da15d4095d1da392a0d2f8ed0c6c7bc0f4cfac8c280b56d` |
+| JITOSOL/USD | `AxaxyeDT8JnWERSaTKvFXvPKkEdxnamKSqpWbsSjYg1g` | `67be9f519b95cf24338801051f9a808eff0a578ccb388db73b7f6fe1de019ffb` |
+| MSOL/USD    | `5CKzb9j4ChgLUt8Gfm5CNGLN6khXKiqMbnGAW4cgXgxK` | `c2289a6a43d2ce91c6f55caec370f4acc38a2ed477f58813334c6d03749ff2a4` |
+| BSOL/USD    | `5cN76Xm2Dtx9MnrQqBDeZZRsWruTTcw37UruznAdSvvE` | `89875379e70f8fbadc17aef315adf3a8d5d160b811435537e03c97e8aac97d9c` |
+| BONK/USD    | `DBE3N8uNjhKPRHfANdwGvCZghWXyLPdqdSbEW2XFwBiX` | `72b021217ca3fe68922a19aaf990109cb9d84e9ad004b4d2025ad6f529314419` |
+| W/USD       | `BEMsCSQEGi2kwPA4mKnGjxnreijhMki7L4eeb96ypzF9` | `eff7446475e218517566ea99e72a4abec2e1bd8498b43b7d8331e29dcb059389` |
+| TNSR/USD    | `9TSGDwcPQX4JpAvZbu2Wp5b68wSYkQvHCvfeBjYcCyC`  | `05ecd4597cd48fe13d6cc3596c62af4f9675aee06e2e0b94c06d8bee2b659e05` |
+| USDC/USD    | `Dpw1EAVrSB1ibxiDQyTAW6Zip3J4Btk2x4SgApQCeFbX` | `eaa020c61cc479712813461ce153894a96a6c00b21ed0cfc2798d1f9a9e9c94a` |
+| BTC/USD     | `4cSM2e6rvbGQUFiJbqytoVMi5GgghSMr8LwVrT9VPSPo` | `e62df6c8b4a85fe1a67db44dc12de5db330f7ac66b72dc658afedf0f4a415b43` |
+| JTO/USD     | `7ajR2zA4MGMMTqRAVjghTKqPPn4kbrj3pYkAVRVwTGzP` | `b43660a5f790c69354b0729a5ef9d50d68f1df92107540210b9cccba1f947cc2` |
+| USDT/USD    | `HT2PLQBcG5EiCcNSaMHAjSgd9F98ecpATbk4Sk5oYuM`  | `2b89b9dc8fdf9f34709a5b106b472f0f39bb6ca9ce04b0fd7f2e971688e2e53b` |
+| JUP/USD     | `7dbob1psH1iZBS7qPsm3Kwbf5DzSXK8Jyg31CTgTnxH5` | `0a0408d619e9380abad35060f9192039ed5042fa6f82301d0e48bb52be830996` |
+| ETH/USD     | `5JwbqPPMNpzE2jVAdobWo6m5gkhsDhRdGBo3FYbSfmaK` | `c96458d393fe9deb7a7d63a0ac41e2898a67a7750dbd166673279e06c868df0a` |
+| PYTH/USD    | `8vjchtMuJNY4oFQdTi8yCe6mhCaNBFaUbktT482TpLPS` | `0bbf28e9a841a1cc788f6a361b17ca072d0ea3098a1e5df1c3922d06719579ff` |
+| HNT/USD     | `4DdmDswskDxXGpwHrXUfn2CNUm9rt21ac79GHNTN3J33` | `649fdd7ec08e8e2a20f425729854e90293dcbe2376abc47197a14da6ff339756` |
+| RNDR/USD    | `GbgH1oen3Ne1RY4LwDgh8kEeA1KywHvs5x8zsx6uNV5M` | `ab7347771135fc733f8f38db462ba085ed3309955f42554a14fa13e855ac0e2f` |
+| ORCA/USD    | `4CBshVeNBEXz24GZpoj8SrqP5L7VGG3qjGd6tCST1pND` | `37505261e557e251290b8c8899453064e8d760ed5c65a779726f2490980da74c` |
+| SAMO/USD    | `2eUVzcYccqXzsDU1iBuatUaDCbRKBjegEaPPeChzfocG` | `49601625e1a342c1f90c3fe6a03ae0251991a1d76e480d2741524c29037be28a` |
+| WIF/USD     | `6B23K3tkb51vLZA14jcEQVCA1pfHptzEHFA93V5dYwbT` | `4ca4beeca86f0d164160323817a4e42b10010a724c2217c6ee41b54cd4cc61fc` |

--- a/pages/price-feeds/sponsored-feeds.mdx
+++ b/pages/price-feeds/sponsored-feeds.mdx
@@ -1,7 +1,11 @@
 # Sponsored Feeds
 
-The Pyth Data Association sponsors price updates for several price feeds in Solana mainnet and devnet.
-The accounts listed in the table below are shard 0 for the relevant price feed id:
+The Pyth Data Association sponsors price updates for some feeds on some networks
+
+## Solana
+
+The price feeds listed in the table below are currently sponsored in Solana mainnet and devnet.
+The addresses represent the price feed account for shard 0 of the relevant price feed id:
 
 | Name        | Account Address                                | Price Feed Id                                                      |
 | ----------- | ---------------------------------------------- | ------------------------------------------------------------------ |
@@ -24,3 +28,5 @@ The accounts listed in the table below are shard 0 for the relevant price feed i
 | ORCA/USD    | `4CBshVeNBEXz24GZpoj8SrqP5L7VGG3qjGd6tCST1pND` | `37505261e557e251290b8c8899453064e8d760ed5c65a779726f2490980da74c` |
 | SAMO/USD    | `2eUVzcYccqXzsDU1iBuatUaDCbRKBjegEaPPeChzfocG` | `49601625e1a342c1f90c3fe6a03ae0251991a1d76e480d2741524c29037be28a` |
 | WIF/USD     | `6B23K3tkb51vLZA14jcEQVCA1pfHptzEHFA93V5dYwbT` | `4ca4beeca86f0d164160323817a4e42b10010a724c2217c6ee41b54cd4cc61fc` |
+| LST/USD     | `7aT9A5knp62jVvnEW33xaWopaPHa3Y7ggULyYiUsDhu8` | `12fb674ee496045b1d9cf7d5e65379acb026133c2ad69f3ed996fb9fe68e3a37` |
+| INF/USD     | `Ceg5oePJv1a6RR541qKeQaTepvERA3i8SvyueX9tT8Sq` | `f51570985c642c49c2d6e50156390fdba80bb6d5f7fa389d2f012ced4f7d208f` |

--- a/pages/price-feeds/use-real-time-data/solana.mdx
+++ b/pages/price-feeds/use-real-time-data/solana.mdx
@@ -116,8 +116,8 @@ const solUsdPriceFeedAccount = pythSolanaReceiver
 ```
 
 The price feed account integration assumes that an off-chain process is continuously updating each price feed.
-The Pyth Data Association is running an off-chain process that continuously schedules price updates for a subset of commonly-used price feeds on shard 0.
-TODO: put in the list of account addresses and feeds somewhere.
+The Pyth Data Association sponsors price updates for a subset of commonly-used price feeds on shard 0.
+Please see [Sponsored Feeds](/price-feeds/sponsored-feeds) for a list of sponsored feeds and their account addresses.
 However, updating a price feed is a permissionless operation, and anyone can run this process.
 Please see [Using Scheduler](/price-feeds/schedule-price-updates/using-scheduler) for more information.
 Running the scheduler can help with reliability and to update feed/shard pairs that are not part of the default schedule.

--- a/pages/price-feeds/use-real-time-data/solana.mdx
+++ b/pages/price-feeds/use-real-time-data/solana.mdx
@@ -107,7 +107,7 @@ const connection: Connection;
 const wallet: AnchorWallet;
 const pythSolanaReceiver = new PythSolanaReceiver({ connection, wallet });
 
-// There are up to 255 different accounts for any given price feed id.
+// There are up to 2^16 different accounts for any given price feed id.
 // The 0 value below is the shard id that indicates which of these accounts you would like to use.
 // However, you may choose to use a different shard to prevent Solana congestion on another app from affecting your app.
 const solUsdPriceFeedAccount = pythSolanaReceiver

--- a/pages/price-feeds/use-real-time-data/solana.mdx
+++ b/pages/price-feeds/use-real-time-data/solana.mdx
@@ -74,25 +74,27 @@ pub fn sample(ctx: Context<Sample>) -> Result<()> {
 Warning: it is your responsibility to validate that the provided price update is for the appropriate price feed and timestamp.
 `PriceUpdateV2` guarantees that the account contains a verified price for _some_ price feed at _some_ point in time.
 There are various methods on this struct (such as `get_price_no_older_than`) that you can use to implement the necessary checks.
-Note: if you choose the price feed account integration (see below), you can use an account id check to validate the price feed id.
+Note: if you choose the price feed account integration (see below), you can use an account address check to validate the price feed id.
 
 ## Write Frontend Code
 
-There are two different types of accounts that developers can use to access Pyth prices on Solana:
+There are two different paths to the frontend integration of Pyth prices on Solana.
+Developers can choose to use two different types of accounts:
 
 - **Price feed accounts** hold a sequence of prices for a specific price feed id that always moves forward in time.
+  These accounts have a fixed address that your program can depend on.
   The Pyth Data Association maintains a set of price feed accounts that are continuously updated.
   Such accounts are a good fit for applications that always want to consume the most recent price.
 - **Price update accounts** are ephemeral accounts that anyone can create, overwrite, and close.
-  These accounts are a good fit for applications that want to consume prices at a specific point in time.
+  These accounts are a good fit for applications that want to consume prices for a specific timestamp.
 
 Both price feed accounts and price update accounts work identically from the perspective of the on-chain program.
 However, the frontend integration differs slightly between the two.
-Please choose the relevant option from the two sections below.
+Both options are explained in the sections below, and developers should pick the one that is best suited for their use case.
 
 ### Price Feed Accounts
 
-If you are using price feed accounts, your frontend code simply needs to pass the relevant price feed account to the transaction.
+If you are using price feed accounts, your frontend code simply needs to pass the relevant price feed account address to the transaction.
 Price feed accounts are program-derived addresses and thus the account ID for any price feed can be derived automatically.
 The `PythSolanaReceiver` class provides a method for deriving this information:
 
@@ -115,7 +117,7 @@ const solUsdPriceFeedAccount = pythSolanaReceiver
 
 The price feed account integration assumes that an off-chain process is continuously updating each price feed.
 The Pyth Data Association is running an off-chain process that continuously schedules price updates for a subset of commonly-used price feeds on shard 0.
-TODO: put in the list of account IDs and feeds somewhere.
+TODO: put in the list of account addresses and feeds somewhere.
 However, updating a price feed is a permissionless operation, and anyone can run this process.
 Please see [Using Scheduler](/price-feeds/schedule-price-updates/using-scheduler) for more information.
 Running the scheduler can help with reliability and to update feed/shard pairs that are not part of the default schedule.

--- a/pages/price-feeds/use-real-time-data/solana.mdx
+++ b/pages/price-feeds/use-real-time-data/solana.mdx
@@ -74,15 +74,60 @@ pub fn sample(ctx: Context<Sample>) -> Result<()> {
 Warning: it is your responsibility to validate that the provided price update is for the appropriate price feed and timestamp.
 `PriceUpdateV2` guarantees that the account contains a verified price for _some_ price feed at _some_ point in time.
 There are various methods on this struct (such as `get_price_no_older_than`) that you can use to implement the necessary checks.
+Note: if you choose the price feed account integration (see below), you can use an account id check to validate the price feed id.
 
 ## Write Frontend Code
 
-Your frontend code needs to perform two different tasks:
+There are two different types of accounts that developers can use to access Pyth prices on Solana:
+
+- **Price feed accounts** hold a sequence of prices for a specific price feed id that always moves forward in time.
+  The Pyth Data Association maintains a set of price feed accounts that are continuously updated.
+  Such accounts are a good fit for applications that always want to consume the most recent price.
+- **Price update accounts** are ephemeral accounts that anyone can create, overwrite, and close.
+  These accounts are a good fit for applications that want to consume prices at a specific point in time.
+
+Both price feed accounts and price update accounts work identically from the perspective of the on-chain program.
+However, the frontend integration differs slightly between the two.
+Please choose the relevant option from the two sections below.
+
+### Price Feed Accounts
+
+If you are using price feed accounts, your frontend code simply needs to pass the relevant price feed account to the transaction.
+Price feed accounts are program-derived addresses and thus the account ID for any price feed can be derived automatically.
+The `PythSolanaReceiver` class provides a method for deriving this information:
+
+```typescript copy
+import { PythSolanaReceiver } from "@pythnetwork/pyth-solana-receiver";
+
+// You will need a Connection from @solana/web3.js and an AnchorWallet to create
+// the receiver.
+const connection: Connection;
+const wallet: AnchorWallet;
+const pythSolanaReceiver = new PythSolanaReceiver({ connection, wallet });
+
+// There are up to 255 different accounts for any given price feed id.
+// The 0 value below is the shard id that indicates which of these accounts you would like to use.
+// However, you may choose to use a different shard to prevent Solana congestion on another app from affecting your app.
+const solUsdPriceFeedAccount = pythSolanaReceiver
+  .getPriceFeedAccountAddress(0, SOL_PRICE_FEED_ID)
+  .toBase58();
+```
+
+The price feed account integration assumes that an off-chain process is continuously updating each price feed.
+The Pyth Data Association is running an off-chain process that continuously schedules price updates for a subset of commonly-used price feeds on shard 0.
+TODO: put in the list of account IDs and feeds somewhere.
+However, updating a price feed is a permissionless operation, and anyone can run this process.
+Please see [Using Scheduler](/price-feeds/schedule-price-updates/using-scheduler) for more information.
+Running the scheduler can help with reliability and to update feed/shard pairs that are not part of the default schedule.
+
+### Price Update Accounts
+
+If you are using price update accounts, your frontend code needs to perform two different tasks:
 
 1. Fetch price updates from Hermes
 2. Post the price updates to Solana and invoke your application logic
 
-### Fetch price updates
+#### Fetch price updates
 
 Use `PriceServiceConnection` from `@pythnetwork/price-service-client` to fetch Pyth price updates from Hermes:
 
@@ -108,7 +153,7 @@ const priceUpdateData: string[] = await priceServiceConnection.getLatestVaas([
 console.log(priceUpdateData);
 ```
 
-### Post price updates
+#### Post price updates
 
 Finally, post the price update to the Pyth program on Solana.
 This step will create the price update account that your application reads from.


### PR DESCRIPTION
I decided to add a section on the push updates to the existing Solana docs because most of the directions are the same except this one part.

I also didn't want to call it "push updates" so I'm using the price feed accounts / price update accounts terminology from the SDK docs.