### PR TITLE
Remove hyphens from page names on Getting Started

### DIFF
--- a/pages/price-feeds/getting-started.mdx
+++ b/pages/price-feeds/getting-started.mdx
@@ -10,18 +10,18 @@ The [Learn](#learn) section provides general meterial for anyone interested in u
 
 Developers interested in using Pyth can refer to the following resources:
 
-- [Create your first pyth app](./create-your-first-pyth-app/) is a tutorial that walks the reader through all of the steps required to develop, test and deploy a contract using Pyth price feeds. This guide is tailored toward new developers with less contract development experience.
-- [User real-time price data](./use-real-time-data/) is a how-to guide that provides the minimal steps to integrate price feeds into your app. This guide is targeted towards more experienced developers who know the basics of smart contract development.
+- [Create Your First Pyth App](./create-your-first-pyth-app/) is a tutorial that walks the reader through all of the steps required to develop, test and deploy a contract using Pyth price feeds. This guide is tailored toward new developers with less contract development experience.
+- [Use Real-Time Price Data](./use-real-time-data/) is a how-to guide that provides the minimal steps to integrate price feeds into your app. This guide is targeted towards more experienced developers who know the basics of smart contract development.
 
 In addition to the two guides above, the following resources will be useful for developers as they integrate:
 
-- [API reference](./api-reference.mdx) provides a detailed overview of Pyth's on-chain methods.
+- [API Reference](./api-reference.mdx) provides a detailed overview of Pyth's on-chain methods.
 - [Price Feed IDs](./price-feed-ids.mdx) lists the price feed ids for all the assets supported by Pyth.
-- [Contract addresses](./contract-addresses/) provides the contract addresses for Pyth on different chains.
-- [Best practices](./best-practices.mdx) explains how to use Pyth price feeds safely and effectively in your application.
+- [Contract Addresses](./contract-addresses/) provides the contract addresses for Pyth on different chains.
+- [Best Practices](./best-practices.mdx) explains how to use Pyth price feeds safely and effectively in your application.
 
 ## Learn
 
 For those interested in learning more about Pyth, the following resources are available:
 
-- [How pyth works](./how-pyth-works.mdx) provides a high-level overview of Pyth architecture.
+- [How Pyth Works](./how-pyth-works.mdx) provides a high-level overview of Pyth architecture.

--- a/pages/price-feeds/getting-started.mdx
+++ b/pages/price-feeds/getting-started.mdx
@@ -10,18 +10,18 @@ The [Learn](#learn) section provides general meterial for anyone interested in u
 
 Developers interested in using Pyth can refer to the following resources:
 
-- [Create-your-first-pyth-app](./create-your-first-pyth-app/) is a tutorial that walks the reader through all of the steps required to develop, test and deploy a contract using Pyth price feeds. This guide is tailored toward new developers with less contract development experience.
-- [User-real-time-data](./use-real-time-data/) is a how-to guide that provides the minimal steps to integrate price feeds into your app. This guide is targeted towards more experienced developers who know the basics of smart contract development.
+- [Create your first pyth app](./create-your-first-pyth-app/) is a tutorial that walks the reader through all of the steps required to develop, test and deploy a contract using Pyth price feeds. This guide is tailored toward new developers with less contract development experience.
+- [User real-time price data](./use-real-time-data/) is a how-to guide that provides the minimal steps to integrate price feeds into your app. This guide is targeted towards more experienced developers who know the basics of smart contract development.
 
 In addition to the two guides above, the following resources will be useful for developers as they integrate:
 
-- [API-reference](./api-reference.mdx) provides a detailed overview of Pyth's on-chain methods.
-- [Price Feed Ids](./price-feed-ids.mdx) lists the price feed ids for all the assets supported by Pyth.
-- [Contract-addresses](./contract-addresses/) provides the contract addresses for Pyth on different chains.
-- [Best-practices](./best-practices.mdx) explains how to use Pyth price feeds safely and effectively in your application.
+- [API reference](./api-reference.mdx) provides a detailed overview of Pyth's on-chain methods.
+- [Price Feed IDs](./price-feed-ids.mdx) lists the price feed ids for all the assets supported by Pyth.
+- [Contract addresses](./contract-addresses/) provides the contract addresses for Pyth on different chains.
+- [Best practices](./best-practices.mdx) explains how to use Pyth price feeds safely and effectively in your application.
 
 ## Learn
 
 For those interested in learning more about Pyth, the following resources are available:
 
-- [How-pyth-works](./how-pyth-works.mdx) provides a high-level overview of Pyth architecture.
+- [How pyth works](./how-pyth-works.mdx) provides a high-level overview of Pyth architecture.


### PR DESCRIPTION
I'm not sure why the page names are hyphenated but they don't need to be.