### PR TITLE
price-feeds/hermes: update github url

### DIFF
--- a/pages/price-feeds/pythnet-price-feeds/hermes.mdx
+++ b/pages/price-feeds/pythnet-price-feeds/hermes.mdx
@@ -7,7 +7,7 @@ to verify and use on-chain.
 Hermes allows users to easily query for recent price updates via a REST API, or subscribe to a websocket for streaming
 updates. The Pyth Network's Javascript SDKs connect to an instance of Hermes to fetch price updates.
 
-[hermes-repo]: https://github.com/pyth-network/pyth-crosschain/tree/main/hermes
+[hermes-repo]: https://github.com/pyth-network/pyth-crosschain/tree/main/apps/hermes
 
 ## Documentation
 


### PR DESCRIPTION
Update documentation to match https://github.com/pyth-network/pyth-crosschain/pull/1421