### PR TITLE
Readd pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,7 @@
+repos:
+  - repo: local
+    hooks:
+      - id: check-prettier
+        name: Check Prettier
+        entry: npm run test:format --
+        language: system

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "test:lint": "next lint",
     "test:unit": "jest",
     "test:types": "tsc --noEmit",
-    "test:format": "prettier --check .",
+    "test:format": "run(){ prettier --check ${*-.}; }; run",
     "fix:lint": "next lint --fix",
     "fix:format": "prettier --write .",
     "postinstall": "graz generate -g"

--- a/shell.nix
+++ b/shell.nix
@@ -69,6 +69,7 @@ in
       pkgs.git
       pkgs.niv
       pkgs.nodejs
+      pkgs.pre-commit
       (
         pkgs.rust-bin.stable.latest.default.override {
           extensions = ["rust-std"];


### PR DESCRIPTION
This PR re-adds the pre-commit config for local development integration, HOWEVER I'm not using it for the github action implementation and am running prettier directly instead.  The reason is that pre-commit doesn't really have a model that makes sense for running tsc or jest tests so we'd likely want to keep those outside of pre-commit anyways, so it's probably cleaner to keep all the tests consistent here rather than trying to match what the rust repos are doing for prettier but not for other checks.  We'll also need to think through monorepo tooling for the `pyth-crosschain` repo in the near future which will change how we implement those hooks in both rust and node repos regardless.