### PR TITLE
Add Cairo syntax highlighting

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,6 +1,24 @@
+const { BUNDLED_LANGUAGES, getHighlighter } = require("shiki");
+
 const withNextra = require("nextra")({
   theme: "nextra-theme-docs",
   themeConfig: "./theme.config.tsx",
+  mdxOptions: {
+    rehypePrettyCodeOptions: {
+      getHighlighter: (options) =>
+        getHighlighter({
+          ...options,
+          langs: [
+            ...BUNDLED_LANGUAGES,
+            {
+              id: "cairo",
+              scopeName: "source.cairo",
+              path: "../../public/syntax/cairo.json",
+            },
+          ],
+        }),
+    },
+  },
 });
 
 // Use this array as a shorter way to specify redirect URLs so we can write down a lot of them.

--- a/pages/price-feeds/use-real-time-data/starknet.mdx
+++ b/pages/price-feeds/use-real-time-data/starknet.mdx
@@ -36,7 +36,7 @@ Pyth also provides a javascript SDK to interact with the Pyth contract on Starkn
 
 The code snippet below provides an example module fetching the STRK/USD price from Pyth price feeds:
 
-```rust {2,17,47,55,64,71-73} copy
+```cairo {2,17,47,55,64,71-73} copy
 use starknet::ContractAddress;
 use pyth::ByteBuffer;
 

--- a/public/syntax/cairo.json
+++ b/public/syntax/cairo.json
@@ -1,0 +1,1153 @@
+{
+  "displayName": "Cairo",
+  "name": "cairo",
+  "patterns": [
+    {
+      "begin": "(<)(\\[)",
+      "beginCaptures": {
+        "1": {
+          "name": "punctuation.brackets.angle.cairo"
+        },
+        "2": {
+          "name": "punctuation.brackets.square.cairo"
+        }
+      },
+      "comment": "boxed slice literal",
+      "end": ">",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.brackets.angle.cairo"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#block-comments"
+        },
+        {
+          "include": "#comments"
+        },
+        {
+          "include": "#gtypes"
+        },
+        {
+          "include": "#lvariables"
+        },
+        {
+          "include": "#punctuation"
+        },
+        {
+          "include": "#types"
+        }
+      ]
+    },
+    {
+      "captures": {
+        "1": {
+          "name": "keyword.operator.macro.dollar.cairo"
+        },
+        "3": {
+          "name": "keyword.other.crate.cairo"
+        },
+        "4": {
+          "name": "entity.name.type.metavariable.cairo"
+        },
+        "6": {
+          "name": "keyword.operator.key-value.cairo"
+        },
+        "7": {
+          "name": "variable.other.metavariable.specifier.cairo"
+        }
+      },
+      "comment": "macro type metavariables",
+      "match": "(\\$)((crate)|([A-Z][A-Za-z0-9_]*))((:)(block|expr|ident|item|literal|meta|path?|stmt|tt|ty|vis))?",
+      "name": "meta.macro.metavariable.type.cairo",
+      "patterns": [
+        {
+          "include": "#keywords"
+        }
+      ]
+    },
+    {
+      "captures": {
+        "1": {
+          "name": "keyword.operator.macro.dollar.cairo"
+        },
+        "2": {
+          "name": "variable.other.metavariable.name.cairo"
+        },
+        "4": {
+          "name": "keyword.operator.key-value.cairo"
+        },
+        "5": {
+          "name": "variable.other.metavariable.specifier.cairo"
+        }
+      },
+      "comment": "macro metavariables",
+      "match": "(\\$)([a-z][A-Za-z0-9_]*)((:)(block|expr|ident|item|literal|meta|path?|stmt|tt|ty|vis))?",
+      "name": "meta.macro.metavariable.cairo",
+      "patterns": [
+        {
+          "include": "#keywords"
+        }
+      ]
+    },
+    {
+      "captures": {
+        "1": {
+          "name": "entity.name.function.macro.rules.cairo"
+        },
+        "3": {
+          "name": "entity.name.function.macro.cairo"
+        },
+        "4": {
+          "name": "entity.name.type.macro.cairo"
+        },
+        "5": {
+          "name": "punctuation.brackets.curly.cairo"
+        }
+      },
+      "comment": "macro rules",
+      "match": "\\b(macro_rules!)\\s+(([a-z0-9_]+)|([A-Z][a-z0-9_]*))\\s+(\\{)",
+      "name": "meta.macro.rules.cairo"
+    },
+    {
+      "captures": {
+        "1": {
+          "name": "storage.type.cairo"
+        },
+        "2": {
+          "name": "entity.name.module.cairo"
+        }
+      },
+      "comment": "modules",
+      "match": "(mod)\\s+((?:r#(?!crate|[Ss]elf|super))?[a-z][A-Za-z0-9_]*)"
+    },
+    {
+      "begin": "\\b(extern)\\s+(crate)",
+      "beginCaptures": {
+        "1": {
+          "name": "storage.type.cairo"
+        },
+        "2": {
+          "name": "keyword.other.crate.cairo"
+        }
+      },
+      "comment": "external crate imports",
+      "end": ";",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.semi.cairo"
+        }
+      },
+      "name": "meta.import.cairo",
+      "patterns": [
+        {
+          "include": "#block-comments"
+        },
+        {
+          "include": "#comments"
+        },
+        {
+          "include": "#keywords"
+        },
+        {
+          "include": "#punctuation"
+        }
+      ]
+    },
+    {
+      "begin": "\\b(use)\\s",
+      "beginCaptures": {
+        "1": {
+          "name": "keyword.other.cairo"
+        }
+      },
+      "comment": "use statements",
+      "end": ";",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.semi.cairo"
+        }
+      },
+      "name": "meta.use.cairo",
+      "patterns": [
+        {
+          "include": "#block-comments"
+        },
+        {
+          "include": "#comments"
+        },
+        {
+          "include": "#keywords"
+        },
+        {
+          "include": "#namespaces"
+        },
+        {
+          "include": "#punctuation"
+        },
+        {
+          "include": "#types"
+        },
+        {
+          "include": "#lvariables"
+        }
+      ]
+    },
+    {
+      "include": "#block-comments"
+    },
+    {
+      "include": "#comments"
+    },
+    {
+      "include": "#attributes"
+    },
+    {
+      "include": "#lvariables"
+    },
+    {
+      "include": "#constants"
+    },
+    {
+      "include": "#gtypes"
+    },
+    {
+      "include": "#functions"
+    },
+    {
+      "include": "#types"
+    },
+    {
+      "include": "#keywords"
+    },
+    {
+      "include": "#macros"
+    },
+    {
+      "include": "#namespaces"
+    },
+    {
+      "include": "#punctuation"
+    },
+    {
+      "include": "#strings"
+    },
+    {
+      "include": "#variables"
+    }
+  ],
+  "repository": {
+    "attributes": {
+      "begin": "(#)(\\!?)(\\[)",
+      "beginCaptures": {
+        "1": {
+          "name": "punctuation.definition.attribute.cairo"
+        },
+        "3": {
+          "name": "punctuation.brackets.attribute.cairo"
+        }
+      },
+      "comment": "attributes",
+      "end": "\\]",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.brackets.attribute.cairo"
+        }
+      },
+      "name": "meta.attribute.cairo",
+      "patterns": [
+        {
+          "include": "#block-comments"
+        },
+        {
+          "include": "#comments"
+        },
+        {
+          "include": "#keywords"
+        },
+        {
+          "include": "#punctuation"
+        },
+        {
+          "include": "#strings"
+        },
+        {
+          "include": "#gtypes"
+        },
+        {
+          "include": "#types"
+        }
+      ]
+    },
+    "block-comments": {
+      "patterns": [
+        {
+          "comment": "empty block comments",
+          "match": "/\\*\\*/",
+          "name": "comment.block.cairo"
+        },
+        {
+          "begin": "/\\*\\*",
+          "comment": "block documentation comments",
+          "end": "\\*/",
+          "name": "comment.block.documentation.cairo",
+          "patterns": [
+            {
+              "include": "#block-comments"
+            }
+          ]
+        },
+        {
+          "begin": "/\\*(?!\\*)",
+          "comment": "block comments",
+          "end": "\\*/",
+          "name": "comment.block.cairo",
+          "patterns": [
+            {
+              "include": "#block-comments"
+            }
+          ]
+        }
+      ]
+    },
+    "comments": {
+      "patterns": [
+        {
+          "captures": {
+            "1": {
+              "name": "punctuation.definition.comment.cairo"
+            }
+          },
+          "comment": "documentation comments",
+          "match": "(///).*$",
+          "name": "comment.line.documentation.cairo"
+        },
+        {
+          "captures": {
+            "1": {
+              "name": "punctuation.definition.comment.cairo"
+            }
+          },
+          "comment": "line comments",
+          "match": "(//).*$",
+          "name": "comment.line.double-slash.cairo"
+        }
+      ]
+    },
+    "constants": {
+      "patterns": [
+        {
+          "comment": "ALL CAPS constants",
+          "match": "\\b[A-Z]{2}[A-Z0-9_]*\\b",
+          "name": "constant.other.caps.cairo"
+        },
+        {
+          "captures": {
+            "1": {
+              "name": "storage.type.cairo"
+            },
+            "2": {
+              "name": "constant.other.caps.cairo"
+            }
+          },
+          "comment": "constant declarations",
+          "match": "\\b(const)\\s+([A-Z][A-Za-z0-9_]*)\\b"
+        },
+        {
+          "captures": {
+            "1": {
+              "name": "punctuation.separator.dot.decimal.cairo"
+            },
+            "2": {
+              "name": "keyword.operator.exponent.cairo"
+            },
+            "3": {
+              "name": "keyword.operator.exponent.sign.cairo"
+            },
+            "4": {
+              "name": "constant.numeric.decimal.exponent.mantissa.cairo"
+            },
+            "5": {
+              "name": "entity.name.type.numeric.cairo"
+            }
+          },
+          "comment": "decimal integers and floats",
+          "match": "\\b\\d[\\d_]*(\\.?)[\\d_]*(?:(E|e)([+-]?)([\\d_]+))?(f32|f64|i128|i16|i32|i64|i8|isize|u128|u16|u32|u64|u8|usize)?\\b",
+          "name": "constant.numeric.decimal.cairo"
+        },
+        {
+          "captures": {
+            "1": {
+              "name": "entity.name.type.numeric.cairo"
+            }
+          },
+          "comment": "hexadecimal integers",
+          "match": "\\b0x[\\da-fA-F_]+(i128|i16|i32|i64|i8|isize|u128|u16|u32|u64|u8|usize)?\\b",
+          "name": "constant.numeric.hex.cairo"
+        },
+        {
+          "captures": {
+            "1": {
+              "name": "entity.name.type.numeric.cairo"
+            }
+          },
+          "comment": "octal integers",
+          "match": "\\b0o[0-7_]+(i128|i16|i32|i64|i8|isize|u128|u16|u32|u64|u8|usize)?\\b",
+          "name": "constant.numeric.oct.cairo"
+        },
+        {
+          "captures": {
+            "1": {
+              "name": "entity.name.type.numeric.cairo"
+            }
+          },
+          "comment": "binary integers",
+          "match": "\\b0b[01_]+(i128|i16|i32|i64|i8|isize|u128|u16|u32|u64|u8|usize)?\\b",
+          "name": "constant.numeric.bin.cairo"
+        },
+        {
+          "comment": "booleans",
+          "match": "\\b(true|false)\\b",
+          "name": "constant.language.bool.cairo"
+        }
+      ]
+    },
+    "escapes": {
+      "captures": {
+        "1": {
+          "name": "constant.character.escape.backslash.cairo"
+        },
+        "2": {
+          "name": "constant.character.escape.bit.cairo"
+        },
+        "3": {
+          "name": "constant.character.escape.unicode.cairo"
+        },
+        "4": {
+          "name": "constant.character.escape.unicode.punctuation.cairo"
+        },
+        "5": {
+          "name": "constant.character.escape.unicode.punctuation.cairo"
+        }
+      },
+      "comment": "escapes: ASCII, byte, Unicode, quote, regex",
+      "match": "(\\\\)(?:(?:(x[0-7][\\da-fA-F])|(u(\\{)[\\da-fA-F]{4,6}(\\}))|.))",
+      "name": "constant.character.escape.cairo"
+    },
+    "functions": {
+      "patterns": [
+        {
+          "captures": {
+            "1": {
+              "name": "keyword.other.cairo"
+            },
+            "2": {
+              "name": "punctuation.brackets.round.cairo"
+            }
+          },
+          "comment": "pub as a function",
+          "match": "\\b(pub)(\\()"
+        },
+        {
+          "begin": "\\b(fn)\\s+((?:r#(?!crate|[Ss]elf|super))?[A-Za-z0-9_]+)((\\()|(<))",
+          "beginCaptures": {
+            "1": {
+              "name": "keyword.other.fn.cairo"
+            },
+            "2": {
+              "name": "entity.name.function.cairo"
+            },
+            "4": {
+              "name": "punctuation.brackets.round.cairo"
+            },
+            "5": {
+              "name": "punctuation.brackets.angle.cairo"
+            }
+          },
+          "comment": "function definition",
+          "end": "\\{|;",
+          "endCaptures": {
+            "0": {
+              "name": "punctuation.brackets.curly.cairo"
+            }
+          },
+          "name": "meta.function.definition.cairo",
+          "patterns": [
+            {
+              "include": "#block-comments"
+            },
+            {
+              "include": "#comments"
+            },
+            {
+              "include": "#keywords"
+            },
+            {
+              "include": "#lvariables"
+            },
+            {
+              "include": "#constants"
+            },
+            {
+              "include": "#gtypes"
+            },
+            {
+              "include": "#functions"
+            },
+            {
+              "include": "#macros"
+            },
+            {
+              "include": "#namespaces"
+            },
+            {
+              "include": "#punctuation"
+            },
+            {
+              "include": "#strings"
+            },
+            {
+              "include": "#types"
+            },
+            {
+              "include": "#variables"
+            }
+          ]
+        },
+        {
+          "begin": "((?:r#(?!crate|[Ss]elf|super))?[A-Za-z0-9_]+)(\\()",
+          "beginCaptures": {
+            "1": {
+              "name": "entity.name.function.cairo"
+            },
+            "2": {
+              "name": "punctuation.brackets.round.cairo"
+            }
+          },
+          "comment": "function/method calls, chaining",
+          "end": "\\)",
+          "endCaptures": {
+            "0": {
+              "name": "punctuation.brackets.round.cairo"
+            }
+          },
+          "name": "meta.function.call.cairo",
+          "patterns": [
+            {
+              "include": "#block-comments"
+            },
+            {
+              "include": "#comments"
+            },
+            {
+              "include": "#attributes"
+            },
+            {
+              "include": "#keywords"
+            },
+            {
+              "include": "#lvariables"
+            },
+            {
+              "include": "#constants"
+            },
+            {
+              "include": "#gtypes"
+            },
+            {
+              "include": "#functions"
+            },
+            {
+              "include": "#macros"
+            },
+            {
+              "include": "#namespaces"
+            },
+            {
+              "include": "#punctuation"
+            },
+            {
+              "include": "#strings"
+            },
+            {
+              "include": "#types"
+            },
+            {
+              "include": "#variables"
+            }
+          ]
+        },
+        {
+          "begin": "((?:r#(?!crate|[Ss]elf|super))?[A-Za-z0-9_]+)(?=::<.*>\\()",
+          "beginCaptures": {
+            "1": {
+              "name": "entity.name.function.cairo"
+            }
+          },
+          "comment": "function/method calls with turbofish",
+          "end": "\\)",
+          "endCaptures": {
+            "0": {
+              "name": "punctuation.brackets.round.cairo"
+            }
+          },
+          "name": "meta.function.call.cairo",
+          "patterns": [
+            {
+              "include": "#block-comments"
+            },
+            {
+              "include": "#comments"
+            },
+            {
+              "include": "#attributes"
+            },
+            {
+              "include": "#keywords"
+            },
+            {
+              "include": "#lvariables"
+            },
+            {
+              "include": "#constants"
+            },
+            {
+              "include": "#gtypes"
+            },
+            {
+              "include": "#functions"
+            },
+            {
+              "include": "#macros"
+            },
+            {
+              "include": "#namespaces"
+            },
+            {
+              "include": "#punctuation"
+            },
+            {
+              "include": "#strings"
+            },
+            {
+              "include": "#types"
+            },
+            {
+              "include": "#variables"
+            }
+          ]
+        }
+      ]
+    },
+    "gtypes": {
+      "patterns": [
+        {
+          "comment": "option types",
+          "match": "\\b(Some|None)\\b",
+          "name": "entity.name.type.option.cairo"
+        },
+        {
+          "comment": "result types",
+          "match": "\\b(Ok|Err)\\b",
+          "name": "entity.name.type.result.cairo"
+        }
+      ]
+    },
+    "interpolations": {
+      "captures": {
+        "1": {
+          "name": "punctuation.definition.interpolation.cairo"
+        },
+        "2": {
+          "name": "punctuation.definition.interpolation.cairo"
+        }
+      },
+      "comment": "curly brace interpolations",
+      "match": "({)[^\"{}]*(})",
+      "name": "meta.interpolation.cairo"
+    },
+    "keywords": {
+      "patterns": [
+        {
+          "comment": "control flow keywords",
+          "match": "\\b(await|break|continue|do|else|for|if|loop|match|return|try|while|yield)\\b",
+          "name": "keyword.control.cairo"
+        },
+        {
+          "comment": "storage keywords",
+          "match": "\\b(extern|let|macro|mod)\\b",
+          "name": "keyword.other.cairo storage.type.cairo"
+        },
+        {
+          "comment": "const keyword",
+          "match": "\\b(const)\\b",
+          "name": "storage.modifier.cairo"
+        },
+        {
+          "comment": "type keyword",
+          "match": "\\b(type)\\b",
+          "name": "keyword.declaration.type.cairo storage.type.cairo"
+        },
+        {
+          "comment": "enum keyword",
+          "match": "\\b(enum)\\b",
+          "name": "keyword.declaration.enum.cairo storage.type.cairo"
+        },
+        {
+          "comment": "trait keyword",
+          "match": "\\b(trait)\\b",
+          "name": "keyword.declaration.trait.cairo storage.type.cairo"
+        },
+        {
+          "comment": "struct keyword",
+          "match": "\\b(struct)\\b",
+          "name": "keyword.declaration.struct.cairo storage.type.cairo"
+        },
+        {
+          "comment": "storage modifiers",
+          "match": "\\b(abstract|static)\\b",
+          "name": "storage.modifier.cairo"
+        },
+        {
+          "comment": "other keywords",
+          "match": "\\b(as|async|become|box|dyn|move|final|gen|impl|in|override|priv|pub|ref|typeof|union|unsafe|unsized|use|virtual|where)\\b",
+          "name": "keyword.other.cairo"
+        },
+        {
+          "comment": "fn",
+          "match": "\\bfn\\b",
+          "name": "keyword.other.fn.cairo"
+        },
+        {
+          "comment": "crate",
+          "match": "\\bcrate\\b",
+          "name": "keyword.other.crate.cairo"
+        },
+        {
+          "comment": "mut",
+          "match": "\\bmut\\b",
+          "name": "storage.modifier.mut.cairo"
+        },
+        {
+          "comment": "logical operators",
+          "match": "(\\^|\\||\\|\\||&&|<<|>>|!)(?!=)",
+          "name": "keyword.operator.logical.cairo"
+        },
+        {
+          "comment": "logical AND, borrow references",
+          "match": "&(?![&=])",
+          "name": "keyword.operator.borrow.and.cairo"
+        },
+        {
+          "comment": "assignment operators",
+          "match": "(\\+=|-=|\\*=|/=|%=|\\^=|&=|\\|=|<<=|>>=)",
+          "name": "keyword.operator.assignment.cairo"
+        },
+        {
+          "comment": "single equal",
+          "match": "(?<![<>])=(?!=|>)",
+          "name": "keyword.operator.assignment.equal.cairo"
+        },
+        {
+          "comment": "comparison operators",
+          "match": "(=(=)?(?!>)|!=|<=|(?<!=)>=)",
+          "name": "keyword.operator.comparison.cairo"
+        },
+        {
+          "comment": "math operators",
+          "match": "(([+%]|(\\*(?!\\w)))(?!=))|(-(?!>))|(/(?!/))",
+          "name": "keyword.operator.math.cairo"
+        },
+        {
+          "captures": {
+            "1": {
+              "name": "punctuation.brackets.round.cairo"
+            },
+            "2": {
+              "name": "punctuation.brackets.square.cairo"
+            },
+            "3": {
+              "name": "punctuation.brackets.curly.cairo"
+            },
+            "4": {
+              "name": "keyword.operator.comparison.cairo"
+            },
+            "5": {
+              "name": "punctuation.brackets.round.cairo"
+            },
+            "6": {
+              "name": "punctuation.brackets.square.cairo"
+            },
+            "7": {
+              "name": "punctuation.brackets.curly.cairo"
+            }
+          },
+          "comment": "less than, greater than (special case)",
+          "match": "(?:\\b|(?:(\\))|(\\])|(\\})))[ \\t]+([<>])[ \\t]+(?:\\b|(?:(\\()|(\\[)|(\\{)))"
+        },
+        {
+          "comment": "namespace operator",
+          "match": "::",
+          "name": "keyword.operator.namespace.cairo"
+        },
+        {
+          "captures": {
+            "1": {
+              "name": "keyword.operator.dereference.cairo"
+            }
+          },
+          "comment": "dereference asterisk",
+          "match": "(\\*)(?=\\w+)"
+        },
+        {
+          "comment": "subpattern binding",
+          "match": "@",
+          "name": "keyword.operator.subpattern.cairo"
+        },
+        {
+          "comment": "dot access",
+          "match": "\\.(?!\\.)",
+          "name": "keyword.operator.access.dot.cairo"
+        },
+        {
+          "comment": "ranges, range patterns",
+          "match": "\\.{2}(=|\\.)?",
+          "name": "keyword.operator.range.cairo"
+        },
+        {
+          "comment": "colon",
+          "match": ":(?!:)",
+          "name": "keyword.operator.key-value.cairo"
+        },
+        {
+          "comment": "dashrocket, skinny arrow",
+          "match": "->",
+          "name": "keyword.operator.arrow.skinny.cairo"
+        },
+        {
+          "comment": "hashrocket, fat arrow",
+          "match": "=>",
+          "name": "keyword.operator.arrow.fat.cairo"
+        },
+        {
+          "comment": "dollar macros",
+          "match": "\\$",
+          "name": "keyword.operator.macro.dollar.cairo"
+        },
+        {
+          "comment": "question mark operator, questionably sized, macro kleene matcher",
+          "match": "\\?",
+          "name": "keyword.operator.question.cairo"
+        }
+      ]
+    },
+    "lvariables": {
+      "patterns": [
+        {
+          "comment": "self",
+          "match": "\\b[Ss]elf\\b",
+          "name": "variable.language.self.cairo"
+        },
+        {
+          "comment": "super",
+          "match": "\\bsuper\\b",
+          "name": "variable.language.super.cairo"
+        }
+      ]
+    },
+    "macros": {
+      "patterns": [
+        {
+          "captures": {
+            "2": {
+              "name": "entity.name.function.macro.cairo"
+            },
+            "3": {
+              "name": "entity.name.type.macro.cairo"
+            }
+          },
+          "comment": "macros",
+          "match": "(([a-z_][A-Za-z0-9_]*!)|([A-Z_][A-Za-z0-9_]*!))",
+          "name": "meta.macro.cairo"
+        }
+      ]
+    },
+    "namespaces": {
+      "patterns": [
+        {
+          "captures": {
+            "1": {
+              "name": "entity.name.namespace.cairo"
+            },
+            "2": {
+              "name": "keyword.operator.namespace.cairo"
+            }
+          },
+          "comment": "namespace (non-type, non-function path segment)",
+          "match": "(?<![A-Za-z0-9_])([A-Za-z0-9_]+)((?<!super|self)::)"
+        }
+      ]
+    },
+    "punctuation": {
+      "patterns": [
+        {
+          "comment": "comma",
+          "match": ",",
+          "name": "punctuation.comma.cairo"
+        },
+        {
+          "comment": "curly braces",
+          "match": "[{}]",
+          "name": "punctuation.brackets.curly.cairo"
+        },
+        {
+          "comment": "parentheses, round brackets",
+          "match": "[()]",
+          "name": "punctuation.brackets.round.cairo"
+        },
+        {
+          "comment": "semicolon",
+          "match": ";",
+          "name": "punctuation.semi.cairo"
+        },
+        {
+          "comment": "square brackets",
+          "match": "[\\[\\]]",
+          "name": "punctuation.brackets.square.cairo"
+        },
+        {
+          "comment": "angle brackets",
+          "match": "(?<!=)[<>]",
+          "name": "punctuation.brackets.angle.cairo"
+        }
+      ]
+    },
+    "strings": {
+      "patterns": [
+        {
+          "begin": "(b?)(\")",
+          "beginCaptures": {
+            "1": {
+              "name": "string.quoted.byte.raw.cairo"
+            },
+            "2": {
+              "name": "punctuation.definition.string.cairo"
+            }
+          },
+          "comment": "double-quoted strings and byte strings",
+          "end": "\"",
+          "endCaptures": {
+            "0": {
+              "name": "punctuation.definition.string.cairo"
+            }
+          },
+          "name": "string.quoted.double.cairo",
+          "patterns": [
+            {
+              "include": "#escapes"
+            },
+            {
+              "include": "#interpolations"
+            }
+          ]
+        },
+        {
+          "begin": "'",
+          "beginCaptures": {
+            "0": {
+              "name": "punctuation.definition.string.cairo"
+            }
+          },
+          "comment": "single-quoted strings",
+          "end": "'",
+          "endCaptures": {
+            "0": {
+              "name": "punctuation.definition.string.cairo"
+            }
+          },
+          "name": "string.quoted.single.cairo",
+          "patterns": [
+            {
+              "include": "#escapes"
+            },
+            {
+              "include": "#interpolations"
+            }
+          ]
+        },
+        {
+          "begin": "(b?r)(#*)(\")",
+          "beginCaptures": {
+            "1": {
+              "name": "string.quoted.byte.raw.cairo"
+            },
+            "2": {
+              "name": "punctuation.definition.string.raw.cairo"
+            },
+            "3": {
+              "name": "punctuation.definition.string.cairo"
+            }
+          },
+          "comment": "double-quoted raw strings and raw byte strings",
+          "end": "(\")(\\2)",
+          "endCaptures": {
+            "1": {
+              "name": "punctuation.definition.string.cairo"
+            },
+            "2": {
+              "name": "punctuation.definition.string.raw.cairo"
+            }
+          },
+          "name": "string.quoted.double.cairo"
+        },
+        {
+          "begin": "(b)?(')",
+          "beginCaptures": {
+            "1": {
+              "name": "string.quoted.byte.raw.cairo"
+            },
+            "2": {
+              "name": "punctuation.definition.char.cairo"
+            }
+          },
+          "comment": "characters and bytes",
+          "end": "'",
+          "endCaptures": {
+            "0": {
+              "name": "punctuation.definition.char.cairo"
+            }
+          },
+          "name": "string.quoted.single.char.cairo",
+          "patterns": [
+            {
+              "include": "#escapes"
+            }
+          ]
+        }
+      ]
+    },
+    "types": {
+      "patterns": [
+        {
+          "captures": {
+            "1": {
+              "name": "entity.name.type.numeric.cairo"
+            }
+          },
+          "comment": "numeric types",
+          "match": "(?<![A-Za-z])(f32|f64|i128|i16|i32|i64|i8|isize|u128|u16|u32|u64|u8|usize)\\b"
+        },
+        {
+          "begin": "\\b(_?[A-Z][A-Za-z0-9_]*)(<)",
+          "beginCaptures": {
+            "1": {
+              "name": "entity.name.type.cairo"
+            },
+            "2": {
+              "name": "punctuation.brackets.angle.cairo"
+            }
+          },
+          "comment": "parameterized types",
+          "end": ">",
+          "endCaptures": {
+            "0": {
+              "name": "punctuation.brackets.angle.cairo"
+            }
+          },
+          "patterns": [
+            {
+              "include": "#block-comments"
+            },
+            {
+              "include": "#comments"
+            },
+            {
+              "include": "#keywords"
+            },
+            {
+              "include": "#lvariables"
+            },
+            {
+              "include": "#punctuation"
+            },
+            {
+              "include": "#types"
+            },
+            {
+              "include": "#variables"
+            }
+          ]
+        },
+        {
+          "comment": "primitive types",
+          "match": "\\b(bool|char|str)\\b",
+          "name": "entity.name.type.primitive.cairo"
+        },
+        {
+          "captures": {
+            "1": {
+              "name": "keyword.declaration.trait.cairo storage.type.cairo"
+            },
+            "2": {
+              "name": "entity.name.type.trait.cairo"
+            }
+          },
+          "comment": "trait declarations",
+          "match": "\\b(trait)\\s+(_?[A-Z][A-Za-z0-9_]*)\\b"
+        },
+        {
+          "captures": {
+            "1": {
+              "name": "keyword.declaration.struct.cairo storage.type.cairo"
+            },
+            "2": {
+              "name": "entity.name.type.struct.cairo"
+            }
+          },
+          "comment": "struct declarations",
+          "match": "\\b(struct)\\s+(_?[A-Z][A-Za-z0-9_]*)\\b"
+        },
+        {
+          "captures": {
+            "1": {
+              "name": "keyword.declaration.enum.cairo storage.type.cairo"
+            },
+            "2": {
+              "name": "entity.name.type.enum.cairo"
+            }
+          },
+          "comment": "enum declarations",
+          "match": "\\b(enum)\\s+(_?[A-Z][A-Za-z0-9_]*)\\b"
+        },
+        {
+          "captures": {
+            "1": {
+              "name": "keyword.declaration.type.cairo storage.type.cairo"
+            },
+            "2": {
+              "name": "entity.name.type.declaration.cairo"
+            }
+          },
+          "comment": "type declarations",
+          "match": "\\b(type)\\s+(_?[A-Z][A-Za-z0-9_]*)\\b"
+        },
+        {
+          "comment": "types",
+          "match": "\\b_?[A-Z][A-Za-z0-9_]*\\b(?!!)",
+          "name": "entity.name.type.cairo"
+        }
+      ]
+    },
+    "variables": {
+      "patterns": [
+        {
+          "comment": "variables",
+          "match": "\\b(?<!(?<!\\.)\\.)(?:r#(?!(crate|[Ss]elf|super)))?[a-z0-9_]+\\b",
+          "name": "variable.other.cairo"
+        }
+      ]
+    }
+  },
+  "scopeName": "source.cairo"
+}


### PR DESCRIPTION
This PR adds a really hacky and probably mostly wrong grammar file for Cairo to fix syntax highlighting issues with single-quoted strings.

I created this grammar file by cloning the Rust grammar from https://github.com/shikijs/textmate-grammars-themes/blob/main/packages/tm-grammars/grammars/rust.json.  I then updated all references to `rust` in the various identifiers to `cairo` instead, and then I removed any references to lifetimes (which is required to ensure the lifetime regex doesn't match before the single-quoted string regex matches) and added a block for handling single-quoted strings (basically just cloning the double-quoted string block and changing the begin and end regex).

I'm not remotely familiar with the textmate grammar syntax so this is almost certainly buggy and incorrect in some ways but it seems to work fine for the code block we have.  We'll just have to test it with any new code blocks and fix as needed.