### PR TITLE
feat: update starknet example

### DIFF
--- a/pages/price-feeds/use-real-time-data/starknet.mdx
+++ b/pages/price-feeds/use-real-time-data/starknet.mdx
@@ -160,7 +160,7 @@ const priceId =
 const currentPrices = await connection.getLatestPriceFeeds([priceId]);
 
 // Convert the price update to Starknet format.
-const pythUpdate = ByteBuffer.fromHex(currentPrices[0].vaa);
+const pythUpdate = ByteBuffer.fromBase64(currentPrices[0].vaa);
 ```
 
 <Callout type="info" emoji="ℹ️">


### PR DESCRIPTION
Updated the example code to match https://github.com/pyth-network/pyth-examples/pull/15. `ByteBuffer.fromBase64` was mistakenly named `ByteBuffer.fromHex`, which have been fixed in `pyth-starknet-js` 0.2.0.