### PR TITLE
Suggested edits

### DIFF
--- a/pages/express-relay/_meta.json
+++ b/pages/express-relay/_meta.json
@@ -28,7 +28,10 @@
     "href": "https://per-staging.dourolabs.app/docs/"
   },
   "contract-addresses": "Contract Addresses",
-  "error-codes": "Error Codes",
+  "error codes": {
+    "title": "Error Codes ↗",
+    "href": "https://www.notion.so/pyth-network/Error-codes-explanation-c90c375eb9a4430494578a713a0d7e68?pvs=4"
+  },
 
   "examples": {
     "title": "Example Application ↗",

--- a/pages/express-relay/_meta.json
+++ b/pages/express-relay/_meta.json
@@ -28,11 +28,7 @@
     "href": "https://per-staging.dourolabs.app/docs/"
   },
   "contract-addresses": "Contract Addresses",
-  "error codes": {
-    "title": "Error Codes ↗",
-    "href": "https://www.notion.so/pyth-network/Error-codes-explanation-c90c375eb9a4430494578a713a0d7e68?pvs=4"
-  },
-
+  "errors": "Error Codes",
   "examples": {
     "title": "Example Application ↗",
     "href": "https://github.com/pyth-network/pyth-crosschain/tree/main/express_relay/examples/easy_lend"

--- a/pages/express-relay/errors.mdx
+++ b/pages/express-relay/errors.mdx
@@ -1,0 +1,33 @@
+# Error Codes
+
+The following table lists the error codes and their explanations for ExpressRelay and OpportunityAdapter contracts.
+They can be used to identify the cause of a failed transaction or bid.
+
+## ExpressRelay
+
+| Error                                        | Selector     | Explanation                                                                                 |
+| -------------------------------------------- | ------------ | ------------------------------------------------------------------------------------------- |
+| `Unauthorized()`                             | `0x82b42900` | This function is called by an unauthorized party.                                           |
+| `InvalidMagicValue()`                        | `0x4ed848c1` | An upgrade was attempted to a contract that does not match the ExpressRelay specification.  |
+| `InvalidPermission()`                        | `0x868a64de` | The provided permissionKey is invalid (too short).                                          |
+| `InvalidFeeSplit()`                          | `0x0601f697` | The proposed fee split is invalid (fee is larger than feePrecision, 10\*\*18).              |
+| `InvalidTargetContract()`                    | `0x5569851a` | The provided target contract is not allowed. (e.g. can not call the ExpressRelay contract). |
+| `DuplicateRelayerSubwallet()`                | `0xb40d37c3` | The provided subwallet to add has already been added.                                       |
+| `RelayerSubwalletNotFound()`                 | `0xac4d92b3` | The provided subwallet to delete does not exist in the store.                               |
+| `ExternalCallFailed(MulticallStatus status)` | `0x740d0306` | The external call failed with the following MulticallStatus output.                         |
+
+## OpportunityAdapter
+
+| Error                                  | Selector     | Explanation                                                                                                      |
+| -------------------------------------- | ------------ | ---------------------------------------------------------------------------------------------------------------- |
+| `NotCalledByExpressRelay()`            | `0xd5668c88` | The OpportunityAdapterFactory contract was not called by the ExpressRelay contract.                              |
+| `NotCalledByFactory()`                 | `0xb02436cc` | The OpportunityAdapter contract was not called by the OpportunityAdapterFactory contract.                        |
+| `AdapterOwnerMismatch()`               | `0x446f3eeb` | The provided executor field does not match the owner of the called OpportunityAdapter contract.                  |
+| `InsufficientTokenReceived()`          | `0x4af147aa` | The specified buyTokens were not received after calling the target contract.                                     |
+| `InsufficientEthToSettleBid()`         | `0x9caaa1d7` | The contract did not receive enough ETH to pay the specified bid.                                                |
+| `InsufficientWethForTargetCallValue()` | `0x5e520cd4` | The contract did not receive enough Wrapped ETH to pay the targetCallValue to the targetContract.                |
+| `TargetCallFailed(bytes returnData)`   | `0xa932c97a` | The call to targetContract failed with the specified returnData.                                                 |
+| `DuplicateToken()`                     | `0x464e3f6a` | There is a duplicate token in either the sellTokens or buyTokens.                                                |
+| `EthOrWethBalanceDecreased()`          | `0x1979776d` | The ETH or WETH balance of the contract decreased as a result of the call to targetContract and the bid payment. |
+| `TargetContractNotAllowed()`           | `0x9c86e59e` | The provided targetContract is not allowed. (e.g. can not call the Permit2 contract).                            |
+| `OnlyOwnerCanCall()`                   | `0x47a8ea58` | Only the owner of the contract can call this method.                                                             |

--- a/pages/express-relay/how-express-relay-works.mdx
+++ b/pages/express-relay/how-express-relay-works.mdx
@@ -1,1 +1,44 @@
-# Design Overview
+# How Express Relay Works
+
+Express Relay allows protocols to eliminate miner-extractable value (MEV).
+Many protocols generate MEV on a regular basis.
+For example, borrow-lending protocols provide bonuses to searchers for liquidating undercollateralized loans.
+Searchers compete for these bonuses by tipping the chain's miners or validators.
+The validators capture most of the value of the liquidation bonus via these tips, so the liquidation bonus is in essence a transfer of wealth from the protocol's users to the validators.
+
+Express Relay solves the problem of MEV by providing protocol developers with an auction primitive that they can use to prioritize access to permissionless operations.
+Developers specify a set of operations in their protocol that must be accessed through Express Relay.
+Searchers then participate in an off-chain auction to access these operations.
+Their bids in the auction determine the priority of their transactions, i.e., the order in which their transactions will be executed.
+The winners transactions are forwarded to the blockchain, which both pays their bid and executes the operation.
+The profits of the auction are then split between the integrated protocol and other participants in Express Relay.
+
+![](images/express_relay/express_relay_schematic.svg)
+
+The diagram above shows how Express Relay changes the MEV landscape for a liquidation.
+In the status quo (left), Searchers tip miners in order to guarantee that their liquidation transaction lands on-chain.
+Their transaction directly interacts with the protocol exposing the liquidation opportunity, and the liquidation bonus flows back to the Searcher.
+With Express Relay (right), Searchers submit bids for their transaction to the Express Relay auction.
+The auction submits the winning bids to the blockchain, where the transactions are processed by the Express Relay Entrypoint before being forwarded on to the integrated protocol.
+The Express Relay Entrypoint collects payment from the Searchers and forwards a share of the revenue back to the integrated protocol.
+
+FIXME: I think the diagram is wrong (specifically the liquidation bonus going back to express relay)
+
+## Which protocols can use Express Relay?
+
+Any protocol with permissionless and valuable operations can use Express Relay.
+These operations generate MEV, as the validators control which searchers can access them.
+Express Relay enables protocols to auction access instead, thereby ensuring the operation is competitively priced.
+Lending, perps, and derivatives protocols with liquidation mechanisms are clear candidates that can benefit from integration with Express Relay.
+
+Aside from eliminating MEV, protocols that need a stable set of searchers may choose to use Express Relay.
+Express Relay provides access to a robust network of searchers who are already active in the Express Relay ecosystem.
+
+## Participants in Express Relay
+
+There are four types of participants in the Express Relay protocol:
+
+- The Relayer runs the off-chain auction and forwards winning transactions onto the blockchain. There is a single Relayer chosen by the Pyth DAO.
+- Protocol developers integrate their protocol with Express Relay in order to eliminate MEV.
+- Searchers participate in auctions to access liquidations and other on-chain opportunities.
+- The Pyth DAO owns and governs the Express Relay system

--- a/pages/express-relay/how-express-relay-works/_meta.json
+++ b/pages/express-relay/how-express-relay-works/_meta.json
@@ -1,10 +1,6 @@
 {
-  "Auction": "auction",
-  "Opportunities": "opportunities",
-  "Permissioning": "permissioning",
-  "Relayer": "relayer",
-  "error codes": {
-    "title": "Error Codes ↗",
-    "href": "https://www.notion.so/pyth-network/Error-codes-explanation-c90c375eb9a4430494578a713a0d7e68?pvs=4"
-  }
+  "auction": "Auction",
+  "opportunities": "Opportunities",
+  "permissioning": "Permissioning",
+  "relayer": "Relayer"
 }

--- a/pages/express-relay/how-express-relay-works/relayer.mdx
+++ b/pages/express-relay/how-express-relay-works/relayer.mdx
@@ -1,0 +1,1 @@
+# Relayer

--- a/pages/express-relay/index.mdx
+++ b/pages/express-relay/index.mdx
@@ -1,32 +1,16 @@
 # Introduction
 
-Many protocols generate MEV on a regular basis. Borrow-lending protocols for example expose lucrative liquidation bonuses that searchers compete for on tips made to the chain's miners or validators. Most of the value in the liquidation opportunity is captured by the validators, so the liquidation bonus is in essence a transfer of wealth from the protocol to the validators.
+Express Relay is a priority auction that enables protocols to eliminate miner-extractable value (MEV).
 
-Express Relay enables protocols to recapture the MEV they currently leak to validators. By integrating with Express Relay, a protocol internalizes the auction for priority on its lucrative transactions (e.g. liquidations). It also taps into an existing set of searchers already integrated into and actively performing liquidations through Express Relay, reducing the need for the protocol to boostrap and maintain or incentivize its own set of liquidators.
+**For Protocol Developers:** Express Relay’s auction primitive allows your protocol to prioritize access to permissionless operations, eliminating the extractive role of miners in ordering transactions.
+A network of established searchers compete in the auctions, allowing you to avoid spending time and energy bootstrapping your own protocol-specific searcher network.
+Learn how to [Integrate with Express Relay as a protocol](/express-relay/integrate-as-protocol).
 
-![](images/express_relay/express_relay_schematic.svg)
+FIXME: This link above and the ones below should be big buttons
 
-## What is Express Relay?
+**For Searchers:** Express Relay aggregates liquidation and other MEV opportunities across integrated DeFi protocols, providing easy and unified access.
+Learn how to [Integrate with Express Relay as a searcher](/express-relay/integrate-as-searcher).
 
-### How does Express Relay work?
+To learn more about Express Relay's design and how it eliminates MEV, please see [How Express Relay Works](/express-relay/how-express-relay-works).
 
-Express Relay features an off-chain auction (run by a third-party entity, the "relayer") where searchers bid on priority rights to transact on a protocol position or opportunity. Once an auction is concluded, the relayer will forward the winning parties' transactions onto the blockchain, where they will pass through the Express Relay entrypoint smart contract before being processed at the end protocol. The entrypoint contract handles permissioning and disbursement of fees to the relevant entities in the system.
-
-### Different types of actors in Express Relay
-
-There are four imporant agents in the Express Relay pipeline:
-
-- Relayer: runs the off-chain auction according to an agreement with the Pyth DAO and forwards winning transactions onto the blockchain
-- Protocol DAO/owner: integrates protocol with Express Relay in order to recapture leaked MEV, which can then be shared with protocol stakeholders
-- Searcher: participates in the Express Relay auction to capture value from lucrative opportunities such as liquidation bonuses
-- Pyth DAO: owner and governing authority of the Express Relay system, designates the relayer to run the off-chain components of the system
-
-### Which protocols can integrate with Express Relay?
-
-Protocols that currently leak MEV to validators because the validators control the ordering of lucrative transactions on the protocol can integrate with Express Relay. By doing so, such a protocol internalizes control over the ordering of these lucrative transactions, which means it does not need to surrender value to the validators.
-
-Apart from recapturing MEV, protocols that are in need of a stable set of searchers that can p . Integrating with Express Relay gives a protocol access to the robust searcher network already active in the Express Relay ecosystem. This means
-
-Lending, perps, and derivatives protocols that use liquidations are an obvious source of MEV and could benefit from integration with Express Relay. In addition,
-
-## Links to other pages
+## Useful Links


### PR DESCRIPTION
I'm out of time right now but here's where I got so far. Main suggestion is to move the explanatory content to the "How Express Relay" works header section and then put in some big CTA buttons on the index page that get people to the integration content. I don't actually know how to put in a button but will figure it out later.

Wanted to send this as a PR though to see if you agree with this organization.

Please merge this if you're happy with it 