### PR TITLE
Fixed an invalid link and improve structure

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8231,9 +8231,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001492",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001492.tgz",
-      "integrity": "sha512-2efF8SAZwgAX1FJr87KWhvuJxnGJKOnctQa8xLOskAXNXq8oiuqgl6u1kk3fFpsp3GgvzlRjiK1sl63hNtFADw==",
+      "version": "1.0.30001644",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001644.tgz",
+      "integrity": "sha512-YGvlOZB4QhZuiis+ETS0VXR+MExbFf4fZYYeMTEE0aTQd/RdIjkTyZjLrbYVKnHzppDvnOhritRVv+i7Go6mHw==",
       "funding": [
         {
           "type": "opencollective",
@@ -28963,9 +28963,9 @@
       "integrity": "sha512-dU+Tx2fsypxTgtLoE36npi3UqcjSSMNYfkqgmoEhtZrraP5VWq0K7FkWVTYa8eMPtnU/G2txVsfdCJTn9uzpuQ=="
     },
     "caniuse-lite": {
-      "version": "1.0.30001492",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001492.tgz",
-      "integrity": "sha512-2efF8SAZwgAX1FJr87KWhvuJxnGJKOnctQa8xLOskAXNXq8oiuqgl6u1kk3fFpsp3GgvzlRjiK1sl63hNtFADw=="
+      "version": "1.0.30001644",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001644.tgz",
+      "integrity": "sha512-YGvlOZB4QhZuiis+ETS0VXR+MExbFf4fZYYeMTEE0aTQd/RdIjkTyZjLrbYVKnHzppDvnOhritRVv+i7Go6mHw=="
     },
     "ccount": {
       "version": "2.0.1",

--- a/pages/price-feeds/create-your-first-pyth-app/evm/part-1.mdx
+++ b/pages/price-feeds/create-your-first-pyth-app/evm/part-1.mdx
@@ -68,7 +68,7 @@ rm -r src/* test/*
 ### Install the Pyth SDK
 
 Pyth provides a Solidity SDK that can be used to interact with one-chain Pyth Price Feed contracts.
-It exposes multiple [methods](../api-reference/evm) to read and interact with the contracts.
+It exposes multiple [methods](/price-feeds/api-reference/evm) to read and interact with the contracts.
 
 Use `npm` to add the Pyth SDK:
 
@@ -333,9 +333,9 @@ contract MyFirstPythContract {
 ```
 
 The end of this function calls the `mint` function we defined before.
-Before that, however, the function calls `[updatePriceFeeds]`(https://docs.pyth.network/price-feeds/api-reference/evm/update-price-feeds) on the Pyth contract.
+Before that, however, the function calls [`updatePriceFeeds`](https://docs.pyth.network/price-feeds/api-reference/evm/update-price-feeds) on the Pyth contract.
 This function takes a payload of `bytes[]` that is passed into the function itself.
-The Pyth contract requires a fee to perform this update; the code snippet above calculates the needed fee using `[getUpdateFee]`(https://docs.pyth.network/price-feeds/api-reference/evm/get-update-fee).
+The Pyth contract requires a fee to perform this update; the code snippet above calculates the needed fee using [`getUpdateFee`](https://docs.pyth.network/price-feeds/api-reference/evm/get-update-fee).
 The caller of this function can pass in a recent Pyth price update as this payload, guaranteeing that the `StalePrice` error won't occur.
 
 We can test this function by adding the following snippet to the test file:
@@ -445,7 +445,7 @@ contract MyFirstPythContract {
 
 ```
 
-And out test file should look like this:
+And our test file should look like this:
 
 ```solidity copy filename="MyFirstPythContract.t.sol"
 // SPDX-License-Identifier: UNLICENSED


### PR DESCRIPTION
1. While going through the `Create-Pyth-App`, I found an invalid link when trying to access `methods` section:

![Screenshot 2024-07-30 135051](https://github.com/user-attachments/assets/c14098a7-574b-41f8-b95b-cea3d52dec57)

This link was invalid and thus showed me a 404 error. Upon investigating, I found that the link was redirected incorrectly and has been corrected.

2. Another change is related to this section:
![Screenshot 2024-07-30 135416](https://github.com/user-attachments/assets/9057101f-e156-4fb7-b4ec-ef52e661f7ac)

Which is now changed to **(those links do work)**:
![Screenshot 2024-07-30 135607](https://github.com/user-attachments/assets/fb8a96b5-2982-4a6c-928a-8c5f7df78d09)

Thanks!
