### PR TITLE
change sui sponsored feeds

### DIFF
--- a/pages/price-feeds/sponsored-feeds.mdx
+++ b/pages/price-feeds/sponsored-feeds.mdx
@@ -56,19 +56,15 @@ The addresses represent the price feed account for shard 0 of the relevant price
 
 ## Sui
 
-The price feeds listed in the table below are currently sponsored in Sui mainnet. The feeds are updated according to the following parameters: 1 second heartbeat or 0.5% price deviation.
+The price feeds listed in the table below are currently sponsored in Sui mainnet. The feeds are updated according to the following parameters: 3 seconds heartbeat or 0.5% price deviation (Except for BTC, ETH, SOL, and SUI - 1s heartbeat or 0.5% price deviation).
 
 | Name      | Price Feed Id                                                      |
 | --------- | ------------------------------------------------------------------ |
-| ADA/USD   | `2a01deaec9e51a579277b34b122399984d0bbf57e2458a7e42fecd2829867a0d` |
 | ARB/USD   | `3fa4252848f9f0a1480be62745a4629d9eb1322aebab8a791e344b3b9c1adcf5` |
 | AVAX/USD  | `93da3352f9f1d105fdfe4971cfa80e9dd777bfc5d0f683ebb6e1294b92137bb7` |
-| BLUR/USD  | `856aac602516addee497edf6f50d39e8c95ae5fb0da1ed434a8c2ab9c3e877e9` |
-| BNB/USD   | `2f95862b045670cd22bee3114c39763a4a08beeb663b145d283c31d7d1101c4f` |
 | BTC/USD   | `e62df6c8b4a85fe1a67db44dc12de5db330f7ac66b72dc658afedf0f4a415b43` |
 | CETUS/USD | `e5b274b2611143df055d6e7cd8d93fe1961716bcd4dca1cad87a83bc1e78c1ef` |
 | DOGE/USD  | `dcef50dd0a4cd2dcc17e45df1676dcb336a11a61c69df7a0299b0150c672d25c` |
-| DOT/USD   | `ca3eed9b267293f6595901c734c7525ce8ef49adafe8284606ceb307afa2ca5b` |
 | ETH/USD   | `ff61491a931112ddf1bd8147cd1b641375f79f5825126d665480874634fd0ace` |
 | LTC/USD   | `6e3f3fa8253588df9326580180233eb791e03b443a3ba7a1d892e73874e19a54` |
 | MATIC/USD | `5de33a9112c2b700b8d30b8a3402c103578ccfa2765696471cc672bd5cf6ac52` |
@@ -88,10 +84,11 @@ The price feeds listed in the table below are currently sponsored in Sui mainnet
 | HASUI/USD | `6120ffcf96395c70aa77e72dcb900bf9d40dccab228efca59a17b90ce423d5e8` |
 | VSUI/USD  | `57ff7100a282e4af0c91154679c5dae2e5dcacb93fd467ea9cb7e58afdcfde27` |
 | FDUSD/USD | `ccdc1a08923e2e4f4b1e6ea89de6acbc5fe1948e9706f5604b8cb50bc1ed3979` |
+| USDY/USD  | `e393449f6aff8a4b6d3e1165a7c9ebec103685f3b41e60db4277b5b6d10e7326` |
 
 ## Aptos
 
-The price feeds listed in the table below are currently sponsored in Aptos mainnet. The feeds are updated according to the following parameters: 2 second heartbeat or 0.5% price deviation.
+The price feeds listed in the table below are currently sponsored in Aptos mainnet. The feeds are updated according to the following parameters: 1 second heartbeat or 0.5% price deviation.
 
 | Name      | Price Feed Id                                                      |
 | --------- | ------------------------------------------------------------------ |


### PR DESCRIPTION
gm

changing the docs for Sui sponsored feeds. Summary below:

- BNB, ADA, DOT, and BLUR are not sponsored anymore
- USDY is now a sponsored feed
- All sponsored feeds update frequency (except BTC, ETH, SOL, and SUI) has been increased from 1 sec to 3 secs
