### PR TITLE
Create your first Pyth app part 1 link changed

### DIFF
--- a/pages/price-feeds/create-your-first-pyth-app/evm/part-2.mdx
+++ b/pages/price-feeds/create-your-first-pyth-app/evm/part-2.mdx
@@ -11,7 +11,7 @@ This part of the tutorial will conver the following:
 - Update and fetch the price from the contract using [pyth-evm-js](https://github.com/pyth-network/pyth-crosschain/tree/main/target_chains/ethereum/sdk/js).
 
 <Callout type="info" emoji="ℹ️">
-  This tutorial is continuation of the [Part 1: Create a Contract](./part1). If
+  This tutorial is continuation of the [Part 1: Create a Contract](./part-1). If
   you haven't completed that part yet, please do so before continuing.
 </Callout>
 


### PR DESCRIPTION
At [Page](https://docs.pyth.network/price-feeds/create-your-first-pyth-app/evm/part-2) This tutorial is continuation of the [Part 1: Create a Contract](https://docs.pyth.network/price-feeds/create-your-first-pyth-app/evm/part1). If you haven't completed that part yet, please do so before continuing.  

The actual link is missing Thats why its showing **404 ERROR** -- Thats corrected
![image](https://github.com/user-attachments/assets/dba5045e-9484-4db0-895e-4327ad093b17)
