### PR TITLE
fix fuel testnet explorer url

### DIFF
--- a/pages/price-feeds/contract-addresses/fuel.mdx
+++ b/pages/price-feeds/contract-addresses/fuel.mdx
@@ -4,7 +4,7 @@ import CopyAddress from "../../../components/CopyAddress";
 
 Pyth is currently deployed on Fuel Mainnet and Fuel Testnet.
 
-| Network      | Contract address                                                                                                                                                                                          |
-| ------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Fuel Mainnet | <CopyAddress address={`0x1c86fdd9e0e7bc0d2ae1bf6817ef4834ffa7247655701ee1b031b52a24c523da`} url="https://app.fuel.network/contract/0x1c86fdd9e0e7bc0d2ae1bf6817ef4834ffa7247655701ee1b031b52a24c523da" /> |
-| Fuel Testnet | <CopyAddress address={`0x25146735b29d4216639f7f8b1d7b921ff87a1d3051de62d6cceaacabeb33b8e7`} url="https://app.fuel.network/contract/0x25146735b29d4216639f7f8b1d7b921ff87a1d3051de62d6cceaacabeb33b8e7" /> |
+| Network      | Contract address                                                                                                                                                                                                  |
+| ------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Fuel Mainnet | <CopyAddress address={`0x1c86fdd9e0e7bc0d2ae1bf6817ef4834ffa7247655701ee1b031b52a24c523da`} url="https://app.fuel.network/contract/0x1c86fdd9e0e7bc0d2ae1bf6817ef4834ffa7247655701ee1b031b52a24c523da" />         |
+| Fuel Testnet | <CopyAddress address={`0x25146735b29d4216639f7f8b1d7b921ff87a1d3051de62d6cceaacabeb33b8e7`} url="https://app-testnet.fuel.network/contract/0x25146735b29d4216639f7f8b1d7b921ff87a1d3051de62d6cceaacabeb33b8e7" /> |


### PR DESCRIPTION
the explorer url changed after the launch of ignition