### PR TITLE
Added clarity on chain id and fixed cast send argument

### DIFF
--- a/pages/entropy/debug-callback-failures.mdx
+++ b/pages/entropy/debug-callback-failures.mdx
@@ -56,6 +56,7 @@ Retrieve the `/v1/chains/$CHAIN_ID/revelations/$SEQUENCE_NUMBER` endpoint from t
 ```bash copy
 curl https://fortuna.dourolabs.app/v1/chains/$CHAIN_ID/revelations/$SEQUENCE_NUMBER
 ```
+N.B. The chain ID is the string name of the chain and not the EVM chain ID. The chain ids are available [here](https://fortuna.dourolabs.app/docs/#/crate%3A%3Aapi/chain_ids)
 
 This endpoint will return the provider's revelation as a hexadecimal value, such as:
 
@@ -77,7 +78,7 @@ export PROVIDER_REVELATION=0x5d4bfa3abeaf15fe8b7771c74c0e3e210096015632831460870
 Finally, submit the transaction to invoke `revealWithCallback`:
 
 ```bash copy
-cast send $ENTROPY_ADDRESS 'revealWithCallback(address, uint64, bytes32, bytes32)' $ENTROPY_ADDRESS $SEQUENCE_NUMBER $USER_RANDOM_NUMBER $PROVIDER_REVELATION
+cast send $ENTROPY_ADDRESS 'revealWithCallback(address, uint64, bytes32, bytes32)' $PROVIDER_ADDRESS $SEQUENCE_NUMBER $USER_RANDOM_NUMBER $PROVIDER_REVELATION
 ```
 
 You may also need to provide the `-r` with an RPC for your chain, plus an additional argument (such as `--private-key`) to specify the wallet to use to sign the transaction.


### PR DESCRIPTION
The chain ID used on the api is not the EVM chain id so it might be a bit misleading, I added an explanation and link to fetch the ids.

The `cast send` call had a bad argument, modified that.