### PR TITLE
Fix grammatical inconsistency in index.mdx

### DIFF
--- a/pages/benchmarks/index.mdx
+++ b/pages/benchmarks/index.mdx
@@ -1,6 +1,6 @@
 # Benchmarks
 
-Pyth benchmarks allow users to query a historical archive of prices from [Price Feeds](price-feeds).
+Pyth Benchmarks allows users to query a historical archive of prices from [Price Feeds](price-feeds).
 For example, applications can retrieve the price of BTC/USD as of last Friday at 8:00 AM UTC.
 This price can be used for contract settlement or any other application that requires historical price data.
 Benchmarks data is signed and verifiable on-chain with the same trust assumptions as Price Feeds.

--- a/pages/benchmarks/index.mdx
+++ b/pages/benchmarks/index.mdx
@@ -1,6 +1,6 @@
 # Benchmarks
 
-Pyth benchmarks allows users to query a historical archive of prices from [Price Feeds](price-feeds).
+Pyth benchmarks allow users to query a historical archive of prices from [Price Feeds](price-feeds).
 For example, applications can retrieve the price of BTC/USD as of last Friday at 8:00 AM UTC.
 This price can be used for contract settlement or any other application that requires historical price data.
 Benchmarks data is signed and verifiable on-chain with the same trust assumptions as Price Feeds.


### PR DESCRIPTION
This update corrects a grammatical inconsistency in the Benchmarks documentation. The original sentence:  

> *Pyth benchmarks allows users to query a historical archive of prices from [[Price Feeds](https://chatgpt.com/c/price-feeds)](price-feeds).*  

has been updated to:  

> *Pyth benchmarks allow users to query a historical archive of prices from [[Price Feeds](https://chatgpt.com/c/price-feeds)](price-feeds).*  

The subject "Pyth benchmarks" refers to a plural concept, so the verb should be "allow" to maintain proper subject-verb agreement.  
