### PR TITLE
fix: Fix incorrect type check in byteArrayFormat function

### DIFF
--- a/utils/InputFormat.tsx
+++ b/utils/InputFormat.tsx
@@ -29,7 +29,7 @@ function byteArrayFormat(x: string): string | undefined {
     const o = JSON.parse(x);
     if (o instanceof Array) {
       for (let i = 0; i < o.length; i++) {
-        if (!(o[i] instanceof Number && o[i] >= 0 && o[i] <= 255)) {
+        if (typeof o[i] !== "number" || o[i] < 0 || o[i] > 255) {
           return "Each entry must be a byte value in [0, 255]";
         }
       }


### PR DESCRIPTION
## Description

Hello!  

While working with the `byteArrayFormat` function, I noticed an issue with the validation logic for array elements. The original condition:  

```javascript
if (!(o[i] instanceof Number && o[i] >= 0 && o[i] <= 255))
```  

...always fails for valid numbers because `instanceof Number` checks for the `Number` object type, not for primitive numbers. Since numbers in JavaScript are typically primitives, this condition doesn't behave as intended.  

I've updated the check to use `typeof` instead, which works correctly for primitive numbers:  

```javascript
if (typeof o[i] !== "number" || o[i] < 0 || o[i] > 255)
```  

This fix ensures that the function correctly validates the elements of the array.

## Type of Change

- [ ] New Page
- [x] Page update/improvement
- [ ] Fix typo/grammar
- [ ] Restructure/reorganize content
- [ ] Update links/references
- [ ] Other (please describe):

## Checklist

- [x] I ran `pre-commit run --all-files` to check for linting errors
- [x] I have reviewed my changes for clarity and accuracy
- [x] All links are valid and working
- [x] Images (if any) are properly formatted and include alt text
- [x] Code examples (if any) are complete and functional
- [x] Content follows the established style guide
- [x] Changes are properly formatted in Markdown
- [x] Preview renders correctly in development environment

## Contributor Information

- Name: Iren
- Email: 0xsimka@gmail.com

