### PR TITLE
unify PROVIDER var in examples on the debug-callback page

### DIFF
--- a/pages/entropy/debug-callback-failures.mdx
+++ b/pages/entropy/debug-callback-failures.mdx
@@ -85,7 +85,7 @@ export PROVIDER_REVELATION=0x5d4bfa3abeaf15fe8b7771c74c0e3e210096015632831460870
 Finally, submit the transaction to invoke `revealWithCallback`:
 
 ```bash copy
-cast send $ENTROPY_ADDRESS 'revealWithCallback(address, uint64, bytes32, bytes32)' $PROVIDER_ADDRESS $SEQUENCE_NUMBER $USER_RANDOM_NUMBER $PROVIDER_REVELATION
+cast send $ENTROPY_ADDRESS 'revealWithCallback(address, uint64, bytes32, bytes32)' $PROVIDER $SEQUENCE_NUMBER $USER_RANDOM_NUMBER $PROVIDER_REVELATION
 ```
 
 You may also need to provide the `-r` with an RPC for your chain, plus an additional argument (such as `--private-key`) to specify the wallet to use to sign the transaction.


### PR DESCRIPTION
## Description

Unify `PROVIDER` bash variable name across example code snippets on [`/entropy/debug-callback-failures`](https://docs.pyth.network/entropy/debug-callback-failures) page.

One code snippet uses `PROVIDER_ADDRESS` bash variable instead of `PROVIDER` which is defined earlier on the page.


## Type of Change

- [ ] New Page
- [x] Page update/improvement
- [ ] Fix typo/grammar
- [ ] Restructure/reorganize content
- [ ] Update links/references
- [ ] Other (please describe):

## Areas Affected

- /entropy/debug-callback-failures

## Checklist

- [x] I ran `pre-commit run --all-files` to check for linting errors
- [x] I have reviewed my changes for clarity and accuracy
- [x] All links are valid and working
- [x] Images (if any) are properly formatted and include alt text
- [x] Code examples (if any) are complete and functional
- [x] Content follows the established style guide
- [x] Changes are properly formatted in Markdown
- [x] Preview renders correctly in development environment

## Contributor Information

- Name: Jakub Niewczas
- Email: niewczas.jakub@gmail.com
