### PR TITLE
Add a page for Adrastia's Pyth Price Feed Updater

### DIFF
--- a/pages/price-feeds/schedule-price-updates.mdx
+++ b/pages/price-feeds/schedule-price-updates.mdx
@@ -8,10 +8,11 @@ The Pyth Data Association sponsors regular on-chain updates for some price feeds
 See [Sponsored Feeds](/price-feeds/sponsored-feeds) for the current list of feeds and their update parameters.
 If you would like to see additional feeds on this list, please [contact the association via this form](https://tally.so/r/nGz2jj).
 
-There are also two different tools to schedule price updates:
+There are also three different tools to schedule price updates:
 
+- [Adrastia's Pyth Price Feed Updater](schedule-price-updates/using-adrastia) is a white-glove service that automates price updates based on time and price deviations, supporting any EVM chain.
 - [Gelato](schedule-price-updates/using-gelato) provides a turnkey automation solution for scheduled updates.
 - [Scheduler](schedule-price-updates/using-scheduler) is a service that developers can run to trigger price updates when certain time or price change conditions are met.
 
-For developers comparing these two options, Gelato is simpler, in that it does not require you to operate a service.
-However, Scheduler supports more blockchains than Gelato.
+For developers comparing these three options, Adrastia and Gelato are simpler, in that they do not require you to operate a service.
+However, Gelato is available on less chains compared to Adrastia and Scheduler.

--- a/pages/price-feeds/schedule-price-updates.mdx
+++ b/pages/price-feeds/schedule-price-updates.mdx
@@ -15,4 +15,3 @@ There are also three different tools to schedule price updates:
 - [Scheduler](schedule-price-updates/using-scheduler) is a service that developers can run to trigger price updates when certain time or price change conditions are met.
 
 For developers comparing these three options, Adrastia and Gelato are simpler, in that they do not require you to operate a service.
-However, Gelato is available on less chains compared to Adrastia and Scheduler.

--- a/pages/price-feeds/schedule-price-updates/_meta.json
+++ b/pages/price-feeds/schedule-price-updates/_meta.json
@@ -1,4 +1,5 @@
 {
+  "using-adrastia": "Using Adrastia",
   "using-gelato": "Using Gelato",
   "using-scheduler": "Using Scheduler"
 }

--- a/pages/price-feeds/schedule-price-updates/using-adrastia.mdx
+++ b/pages/price-feeds/schedule-price-updates/using-adrastia.mdx
@@ -1,0 +1,34 @@
+# Using Adrastia to Schedule Real-Time Price Updates
+
+## About Adrastia
+
+Established in 2021, [Adrastia](https://adrastia.io) is an automation platform founded by TRILEZ SOFTWARE INC. and leverages over a decade of experience in building and running AI agents to deliver reliable, high-performance automated systems. Adrastia operates with the core values of reliability, transparency, and prudence with a focus on enhancing the security, performance, and efficiency of DeFi systems.
+
+## Pyth Price Feed Updater
+
+Adrastia's Pyth Price Feed Updater is a managed white-glove solution that reliably pushes price updates with speed and efficiency when specified trigger conditions are met. The setup process is simple and Adrastia handles all the heavy lifting.
+
+## Process
+
+Adrastia is working on a decentralized, permissionless system for managing this service where you'll be able to effortlessly choose your preferred service provider and manage all details in an app. In the meantime, they've made the offchain integration process as simple as possible.
+
+1. Reach out to them via email ([support@adrastia.io](mailto:support@adrastia.io)) or [Discord](https://discord.adrastia.io/).
+2. Provide them with the price feed IDs for which you'd like to schedule price updates.
+3. They'll create a public (or private) GitHub repository for you to view the configuration and suggest changes.
+4. They'll send you a Service Agreement to authorize.
+5. They'll provide you with a set of Automatos (automation) worker addresses for you to fund with gas.
+6. They'll start the service and provide you with access to a data analytics dashboard.
+7. They'll provide you with a status page for your service, at your request.
+8. They'll bill you at the end of the month.
+
+## Configuration
+
+Every price feed supports updates based on either:
+1. The price changing by at least the specified threshold, or
+2. The heartbeat period being met (i.e. requiring at least one update every so often)
+
+Additionally, every feed also supports early update conditions as an extension of the above criteria. When one feed requires an update based on the regular criteria, additional criteria can be applied to preemptively update other specified price feeds. This early update mechanism saves gas by reducing the amount of update transactions, with the cost savings rooted in performing a minimal amount of proof validations.
+
+## More details
+
+This page covers the key aspects of Adrastia's Pyth Price Feed Updater. For more details including aspects like costs, analytics, terms, and technical specifications, please visit [Adrastia's documentation page](https://docs.adrastia.io/automatos/pyth-price-feed-updater).

--- a/pages/price-feeds/schedule-price-updates/using-adrastia.mdx
+++ b/pages/price-feeds/schedule-price-updates/using-adrastia.mdx
@@ -24,6 +24,7 @@ Adrastia is working on a decentralized, permissionless system for managing this 
 ## Configuration
 
 Every price feed supports updates based on either:
+
 1. The price changing by at least the specified threshold, or
 2. The heartbeat period being met (i.e. requiring at least one update every so often)
 


### PR DESCRIPTION
## Description

Adds a page for Adrastia's Pyth Price Feed Updater.

## Type of Change

- [x] New Page
- [x] Page update/improvement
- [ ] Fix typo/grammar
- [ ] Restructure/reorganize content
- [ ] Update links/references
- [ ] Other (please describe):

## Areas Affected

- price-feeds/schedule-price-updates
- price-feeds/schedule-price-updates/using-adrastia

## Checklist

- [x] I ran `pre-commit run --all-files` to check for linting errors
- [x] I have reviewed my changes for clarity and accuracy
- [x] All links are valid and working
- [x] Images (if any) are properly formatted and include alt text
- [x] Code examples (if any) are complete and functional
- [x] Content follows the established style guide
- [x] Changes are properly formatted in Markdown
- [x] Preview renders correctly in development environment

## Screenshots

![image](https://github.com/user-attachments/assets/9e85ac9f-5c75-4159-b53d-4eaf739119a4)

![image](https://github.com/user-attachments/assets/7d4380c9-3cfb-40a4-9fe4-bcccaea795e5)

