### PR TITLE
Update publisher-quality-ranking.mdx

### DIFF
--- a/pages/home/oracle-integrity-staking/publisher-quality-ranking.mdx
+++ b/pages/home/oracle-integrity-staking/publisher-quality-ranking.mdx
@@ -50,7 +50,7 @@ This section provides a detailed breakdown of how each metric is calculated.
 
 ### Uptime
 
-Uptime measures a publisher's reliability and availability. If a publisher consistently provides data without interruptions, it indicates a high level of reliability. This is aligned with the current conformance testing, which checks the publisher's availability based on price publication within 10 slots.
+Uptime measures a publisher's reliability and availability. If a publisher consistently provides data without interruptions, it indicates a high level of reliability. This is aligned with the current conformance testing, which checks the publisher's availability based on price publication within the number of slots as defined on each feed's "Max Slot Latency" which is available on each feed's web page and within each feed's metadata.
 
 $$
 \text{Score}_{\text{Uptime}} = \frac{\text{Publisher Slot Count}}{\text{Aggregate Slot Count}}


### PR DESCRIPTION
Updating the wording describing the number of slots used to calculate uptime for quality scoring, which has just been changed to use each feed's max slot latency as opposed to the default 10 slots.

## Description

<!-- Provide a clear and concise description of your documentation changes -->

## Type of Change

<!-- Check relevant options by putting an x in the brackets -->

- [ ] New Page
- [x] Page update/improvement
- [ ] Fix typo/grammar
- [ ] Restructure/reorganize content
- [ ] Update links/references
- [ ] Other (please describe):

## Areas Affected
https://docs.pyth.network/home/oracle-integrity-staking/publisher-quality-ranking#uptime-1

## Checklist

<!-- Check items by putting an x in the brackets -->

- [x] I ran `pre-commit run --all-files` to check for linting errors
- [x] I have reviewed my changes for clarity and accuracy
- [x] All links are valid and working
- [x] Images (if any) are properly formatted and include alt text
- [x] Code examples (if any) are complete and functional
- [x] Content follows the established style guide
- [x] Changes are properly formatted in Markdown
- [x] Preview renders correctly in development environment

## Related Issues

<!-- Link any related issues using #issue_number -->

Closes #

## Additional Notes
Aligns with doc normally shared with MDPs:
https://pyth-network.notion.site/Publisher-Quality-Ranking-aaa4ed190c034904bdb85d4316247bf1

## Contributor Information

<!-- Please provide your contact information -->

- Name: Nicholas Diakomihalis
- Email: nicholas@dourolabs.xyz

## Screenshots

<!-- If applicable, add screenshots to help explain your changes -->
