### PR TITLE
fix: solidity param `update` -> `priceUpdate`

### DIFF
--- a/pages/lazer/integrate-as-consumer/evm.mdx
+++ b/pages/lazer/integrate-as-consumer/evm.mdx
@@ -57,7 +57,7 @@ Add an argument of type `bytes calldata{:solidity}` to the method which will rec
 ```solidity copy
 function updatePrice(bytes calldata priceUpdate) public payable {
   uint256 verification_fee = pythLazer.verification_fee();
-  (bytes calldata payload, ) = verifyUpdate{ value: verification_fee }(update);
+  (bytes calldata payload, ) = verifyUpdate{ value: verification_fee }(priceUpdate);
   //...
 }
 


### PR DESCRIPTION
## Description

The solidity example uses an undefined `update` parameter. It should be `priceUpdate`.

## Type of Change

<!-- Check relevant options by putting an x in the brackets -->

- [ ] New Page
- [ ] Page update/improvement
- [x] Fix typo/grammar
- [ ] Restructure/reorganize content
- [ ] Update links/references
- [ ] Other (please describe):

## Areas Affected

## <!-- List the documentation sections/pages that have been modified -->

## Checklist

<!-- Check items by putting an x in the brackets -->

- [ ] I ran `pre-commit run --all-files` to check for linting errors
- [ ] I have reviewed my changes for clarity and accuracy
- [ ] All links are valid and working
- [ ] Images (if any) are properly formatted and include alt text
- [ ] Code examples (if any) are complete and functional
- [ ] Content follows the established style guide
- [ ] Changes are properly formatted in Markdown
- [ ] Preview renders correctly in development environment

## Related Issues

<!-- Link any related issues using #issue_number -->

Closes #

## Additional Notes

<!-- Add any other context about your documentation changes -->

## Contributor Information

<!-- Please provide your contact information -->

- Name:
- Email:

## Screenshots

<!-- If applicable, add screenshots to help explain your changes -->
