### PR TITLE
fix: correct Wormhole subdir path for IOTA in Move.toml

### DIFF
--- a/pages/price-feeds/use-real-time-data/iota.mdx
+++ b/pages/price-feeds/use-real-time-data/iota.mdx
@@ -19,7 +19,7 @@ rev = "iota-contract-testnet"
 
 [dependencies.Wormhole]
 git = "https://github.com/pyth-network/pyth-crosschain.git"
-subdir = "target_chains/sui/contracts/vendor/wormhole_iota_testnet/wormhole"
+subdir = "target_chains/sui/vendor/wormhole_iota_testnet/wormhole"
 rev = "iota-contract-testnet"
 
 [dependencies.Iota]


### PR DESCRIPTION

## Description

Corrected the Wormhole dependency path in `Move.toml` for the IOTA target chain.

The previous path included an extra `contracts` segment, which does not exist in the `iota-contract-testnet` branch of `pyth-crosschain`. This change makes the dependency resolution work as expected.

## Type of Change

- [ ] New Page
- [ ] Page update/improvement
- [x] Fix typo/grammar
- [ ] Restructure/reorganize content
- [x] Update links/references
- [ ] Other (please describe):

## Areas Affected

## <!-- List the documentation sections/pages that have been modified -->

- `target_chains/iota/Move.toml`

## Checklist

<!-- Check items by putting an x in the brackets -->

- [ ] I ran `pre-commit run --all-files` to check for linting errors
- [x] I have reviewed my changes for clarity and accuracy
- [x] All links are valid and working
- [ ] Images (if any) are properly formatted and include alt text
- [ ] Code examples (if any) are complete and functional
- [x] Content follows the established style guide
- [x] Changes are properly formatted in Markdown
- [x] Preview renders correctly in development environment

## Related Issues

<!-- Link any related issues using #issue_number -->

Closes #

## Additional Notes

Tested the IOTA contracts using the updated `Move.toml` — the build now succeeds with the corrected dependency path.

