### PR TITLE
Update use-real-time-data homepage to add missing chains

### DIFF
--- a/pages/price-feeds/use-real-time-data.mdx
+++ b/pages/price-feeds/use-real-time-data.mdx
@@ -12,10 +12,13 @@ Then, consult the relevant ecosystem guide to get started using Pyth real-time p
 
 - [EVM](use-real-time-data/evm)
 - [Solana](use-real-time-data/solana)
+- [Starknet](use-real-time-data/starknet)
+- [Fuel](use-real-time-data/fuel)
 - [Aptos](use-real-time-data/aptos.md)
 - [CosmWasm](use-real-time-data/cosmwasm.md)
 - [Sui](use-real-time-data/sui.md)
 - [IOTA](use-real-time-data/iota.md)
+- [TON](use-real-time-data/ton)
 - [Near](use-real-time-data/sui.md)
 
 Pyth price feeds can also be used in off-chain applications.


### PR DESCRIPTION
The current page body is missing some ecosystems that are available in the left sidebar.

<img width="568" alt="image" src="https://github.com/user-attachments/assets/1015ce68-39fe-41d8-9caa-9cc9d84afd53" />


https://docs.pyth.network/price-feeds/use-real-time-data

This PR adds these new ecosystem in the main page.