### PR TITLE
doc(solana/twap): reduce duplication in example app documentation

### DIFF
--- a/pages/price-feeds/use-real-time-data/solana.mdx
+++ b/pages/price-feeds/use-real-time-data/solana.mdx
@@ -361,20 +361,18 @@ await pythSolanaReceiver.provider.sendAll(
 
 For a complete example of posting TWAP updates to Solana, see the [post_twap_update.ts example script](https://github.com/pyth-network/pyth-crosschain/blob/main/target_chains/solana/sdk/js/pyth_solana_receiver/examples/post_twap_update.ts) in the Pyth crosschain repository.
 
-### Example Application
-
-See an end-to-end example of using Price Update Accounts for spot prices or TWAP Accounts for time-averaged prices in the [SendUSD Solana Demo App](https://github.com/pyth-network/pyth-examples/tree/main/price_feeds/solana/send_usd). It demonstrates how to fetch data from Hermes, post it to Solana, and consume it from a smart contract. The example includes:
-
-- A React frontend for interacting with the contract
-- A Solana program that consumes TWAP updates
-- Complete transaction building for posting and consuming TWAP data
-
-The example allows users to send a USD-denominated amount of SOL using either spot prices or TWAP prices, demonstrating how TWAP can be used to reduce the impact of price volatility.
-
 ## Additional Resources
 
 You may find these additional resources helpful for developing your Solana application.
 
-### Example application
+### Example Application
 
-The [Solana example application](https://github.com/pyth-network/pyth-examples/tree/main/price_feeds/solana/send_usd) is an end-to-end application that uses Pyth Network prices on the Solana blockchain and in a frontend.
+See an end-to-end example of using Pyth Network prices in the [SendUSD Solana Demo App](https://github.com/pyth-network/pyth-examples/tree/main/price_feeds/solana/send_usd). The app allows users to send a USD-denominated amount of SOL using either spot prices or TWAP prices.
+It demonstrates how to fetch price data from Hermes from a frontend, post it to the Solana blockchain, and consume it from a smart contract. The example includes:
+
+- A React frontend for interacting with the contract
+- Solana programs that consumes spot price updates (Price Update Accounts) and time-averaged price updates (TWAP Accounts)
+- Complete transaction building for posting and consuming price data
+
+The example allows users to send a USD-denominated amount of SOL using either spot prices or TWAP prices.
+

--- a/pages/price-feeds/use-real-time-data/solana.mdx
+++ b/pages/price-feeds/use-real-time-data/solana.mdx
@@ -368,11 +368,10 @@ You may find these additional resources helpful for developing your Solana appli
 ### Example Application
 
 See an end-to-end example of using Pyth Network prices in the [SendUSD Solana Demo App](https://github.com/pyth-network/pyth-examples/tree/main/price_feeds/solana/send_usd). The app allows users to send a USD-denominated amount of SOL using either spot prices or TWAP prices.
-It demonstrates how to fetch price data from Hermes from a frontend, post it to the Solana blockchain, and consume it from a smart contract. The example includes:
+It demonstrates how to fetch price data from Hermes from a frontend, post it to the Solana blockchain, and consume it from a smart contract.
+
+The example includes:
 
 - A React frontend for interacting with the contract
 - Solana programs that consumes spot price updates (Price Update Accounts) and time-averaged price updates (TWAP Accounts)
 - Complete transaction building for posting and consuming price data
-
-The example allows users to send a USD-denominated amount of SOL using either spot prices or TWAP prices.
-


### PR DESCRIPTION
## Description

Noticed that the Solana documentation has a [duplicate section about the example app](https://docs.pyth.network/price-feeds/use-real-time-data/solana#example-application). It talks about the example app from the perspective of TWAP, and the next section again repeats this but from the perspective of Price Update Accounts. This change unifies the sections for consistency. See screenshots below: 

## Type of Change

- [ ] New Page
- [x] Page update/improvement
- [ ] Fix typo/grammar
- [x] Restructure/reorganize content
- [ ] Update links/references
- [ ] Other (please describe):

## Areas Affected
https://docs.pyth.network/price-feeds/use-real-time-data/solana#example-application

## Checklist

<!-- Check items by putting an x in the brackets -->

- [x] I ran `pre-commit run --all-files` to check for linting errors
- [x] I have reviewed my changes for clarity and accuracy
- [x] All links are valid and working
- [x] Images (if any) are properly formatted and include alt text
- [x] Code examples (if any) are complete and functional
- [x] Content follows the established style guide
- [x] Changes are properly formatted in Markdown
- [x] Preview renders correctly in development environment

## Screenshots

Before:
<img width="965" alt="image" src="https://github.com/user-attachments/assets/01ed9a7f-d28d-43c8-8dc3-4e863565e0d3" />

After:
<img width="940" alt="image" src="https://github.com/user-attachments/assets/3e70646f-124a-4c0b-860b-876b9d3ae09e" />
