### PR TITLE
Change 'Sonic (Fantom)' to 'Sonic' in EVM Contract Deploy Docs

### DIFF
--- a/pages/price-feeds/contract-addresses/evm.mdx
+++ b/pages/price-feeds/contract-addresses/evm.mdx
@@ -67,7 +67,7 @@ Pyth is currently available on the EVM networks below using Pyth Stable price so
 | Sei EVM               | [`0x2880aB155794e7179c9eE2e38200202908C17B43`](https://seitrace.com/address/0x2880aB155794e7179c9eE2e38200202908C17B43?chain=pacific-1)   |
 | Shimmer               | [`0xA2aa501b19aff244D90cc15a4Cf739D2725B5729`](https://explorer.evm.shimmer.network/address/0xA2aa501b19aff244D90cc15a4Cf739D2725B5729)   |
 | Skate                 | [`0x2880aB155794e7179c9eE2e38200202908C17B43`](https://scan.skatechain.org/address/0x2880aB155794e7179c9eE2e38200202908C17B43)            |
-| Sonic(Fantom)         | [`0x2880aB155794e7179c9eE2e38200202908C17B43`](https://sonicscan.org/address/0x2880ab155794e7179c9ee2e38200202908c17b43)                  |
+| Sonic                 | [`0x2880aB155794e7179c9eE2e38200202908C17B43`](https://sonicscan.org/address/0x2880ab155794e7179c9ee2e38200202908c17b43)                  |
 | Soneium               | [`0x2880aB155794e7179c9eE2e38200202908C17B43`](https://soneium.blockscout.com/address/0x2880aB155794e7179c9eE2e38200202908C17B43)         |
 | Story Protocol        | [`0xD458261E832415CFd3BAE5E416FdF3230ce6F134`](https://www.storyscan.xyz/address/0xD458261E832415CFd3BAE5E416FdF3230ce6F134)              |
 | Swellchain            | [`0xDd24F84d36BF92C65F92307595335bdFab5Bbd21`](https://explorer.swellnetwork.io/address/0xDd24F84d36BF92C65F92307595335bdFab5Bbd21)       |


### PR DESCRIPTION
Change 'Sonic (Fantom)' to 'Sonic'. No reason to have Fantom in the title anymore.

## Description

<!-- Provide a clear and concise description of your documentation changes -->

## Type of Change

<!-- Check relevant options by putting an x in the brackets -->

- [ ] New Page
- [ ] Page update/improvement
- [ ] Fix typo/grammar
- [ ] Restructure/reorganize content
- [ ] Update links/references
- [ ] Other (please describe):

## Areas Affected

## <!-- List the documentation sections/pages that have been modified -->

## Checklist

<!-- Check items by putting an x in the brackets -->

- [ ] I ran `pre-commit run --all-files` to check for linting errors
- [ ] I have reviewed my changes for clarity and accuracy
- [ ] All links are valid and working
- [ ] Images (if any) are properly formatted and include alt text
- [ ] Code examples (if any) are complete and functional
- [ ] Content follows the established style guide
- [ ] Changes are properly formatted in Markdown
- [ ] Preview renders correctly in development environment

## Related Issues

<!-- Link any related issues using #issue_number -->

Closes #

## Additional Notes

<!-- Add any other context about your documentation changes -->

## Contributor Information

<!-- Please provide your contact information -->

- Name:
- Email:

## Screenshots

<!-- If applicable, add screenshots to help explain your changes -->
