### PR TITLE
fix(sui): Update Toml to use New Wormhole Branches

### DIFF
--- a/pages/price-feeds/use-real-time-data/sui.mdx
+++ b/pages/price-feeds/use-real-time-data/sui.mdx
@@ -19,7 +19,7 @@ rev = "sui-contract-mainnet"
 [dependencies.Wormhole]
 git = "https://github.com/wormhole-foundation/wormhole.git"
 subdir = "sui/wormhole"
-rev = "sui-upgrade-mainnet"
+rev = "sui/mainnet"
 
 # Pyth is locked into this specific `rev` because the package depends on Wormhole and is pinned to this version.
 
@@ -40,7 +40,7 @@ rev = "sui-contract-testnet"
 [dependencies.Wormhole]
 git = "https://github.com/wormhole-foundation/wormhole.git"
 subdir = "sui/wormhole"
-rev = "sui-upgrade-testnet"
+rev = "sui/testnet"
 
 # Pyth is locked into this specific `rev` because the package depends on Wormhole and is pinned to this version.
 [dependencies.Sui]

--- a/pages/price-feeds/use-real-time-data/sui.mdx
+++ b/pages/price-feeds/use-real-time-data/sui.mdx
@@ -22,7 +22,6 @@ subdir = "sui/wormhole"
 rev = "sui/mainnet"
 
 # Pyth is locked into this specific `rev` because the package depends on Wormhole and is pinned to this version.
-
 [dependencies.Sui]
 git = "https://github.com/MystenLabs/sui.git"
 subdir = "crates/sui-framework/packages/sui-framework"

--- a/pages/price-feeds/use-real-time-data/sui.mdx
+++ b/pages/price-feeds/use-real-time-data/sui.mdx
@@ -22,6 +22,7 @@ subdir = "sui/wormhole"
 rev = "sui/mainnet"
 
 # Pyth is locked into this specific `rev` because the package depends on Wormhole and is pinned to this version.
+
 [dependencies.Sui]
 git = "https://github.com/MystenLabs/sui.git"
 subdir = "crates/sui-framework/packages/sui-framework"


### PR DESCRIPTION
## Description
Wormhole changed the names of branches they had, which broke dependency pulling in the Move.toml file. I've updated our branch to use the new updated one, so the docs need to be updated to match that change. 

## Type of Change

<!-- Check relevant options by putting an x in the brackets -->

- [ ] New Page
- [x] Page update/improvement
- [ ] Fix typo/grammar
- [ ] Restructure/reorganize content
- [ ] Update links/references
- [ ] Other (please describe):

## Areas Affected

Use Real Time Data Sui Page

## Checklist

<!-- Check items by putting an x in the brackets -->

- [x] I ran `pre-commit run --all-files` to check for linting errors
- [x] I have reviewed my changes for clarity and accuracy
- [x] All links are valid and working
- [x] Images (if any) are properly formatted and include alt text
- [x] Code examples (if any) are complete and functional
- [x] Content follows the established style guide
- [x] Changes are properly formatted in Markdown
- [x] Preview renders correctly in development environment

## Related Issues

<!-- Link any related issues using #issue_number -->

Closes # https://dev-forum.pyth.network/t/sui-move-toml-build-failed-testnet-mainnet-get-sui-price-feed/158

## Additional Notes

We are in discussion with WH to avoid this scenario in the future.

## Contributor Information

<!-- Please provide your contact information -->

- Name: Darun Seethammagari
- Email: darun@dourolabs.xyz

## Screenshots

<!-- If applicable, add screenshots to help explain your changes -->
