### PR TITLE
fix(docs): cast send -j requires # of threads

### DIFF
--- a/pages/price-feeds/create-your-first-pyth-app/evm/part-2.mdx
+++ b/pages/price-feeds/create-your-first-pyth-app/evm/part-2.mdx
@@ -115,7 +115,7 @@ We can do this using `cast` by running the following command:
 cast send \
   --private-key $PRIVATE_KEY \
   --rpc-url $RPC_URL \
-  -j \
+  -j 1 \
   --value 0.0005ether \
   $DEPLOYMENT_ADDRESS \
   "updateAndMint(bytes[])" \


### PR DESCRIPTION
## Description

This command uses `cast send -j` but omits the number of threads. If you run the command as written, you get the error `error: a value is required for '--threads <THREADS>' but none was supplied`. This PR adds 1 as the number of threads.

## Type of Change

<!-- Check relevant options by putting an x in the brackets -->

- [ ] New Page
- [ ] Page update/improvement
- [X] Fix typo/grammar
- [ ] Restructure/reorganize content
- [ ] Update links/references
- [ ] Other (please describe):

## Areas Affected

## <!-- List the documentation sections/pages that have been modified -->

## Checklist

<!-- Check items by putting an x in the brackets -->

- [X] I ran `pre-commit run --all-files` to check for linting errors
- [X] I have reviewed my changes for clarity and accuracy
- [ ] All links are valid and working
- [ ] Images (if any) are properly formatted and include alt text
- [X] Code examples (if any) are complete and functional
- [ ] Content follows the established style guide
- [X] Changes are properly formatted in Markdown
- [X] Preview renders correctly in development environment

## Related Issues

<!-- Link any related issues using #issue_number -->

Closes #

## Additional Notes

<!-- Add any other context about your documentation changes -->

## Contributor Information

<!-- Please provide your contact information -->

- Name:
- Email:

## Screenshots

<!-- If applicable, add screenshots to help explain your changes -->
