### PR TITLE
--broadcast switch required to broadcast the transaction

### DIFF
--- a/pages/price-feeds/create-your-first-pyth-app/evm/part-2.mdx
+++ b/pages/price-feeds/create-your-first-pyth-app/evm/part-2.mdx
@@ -67,6 +67,7 @@ Run the following command:
 forge create src/MyFirstPythContract.sol:MyFirstPythContract \
 --private-key $PRIVATE_KEY \
 --rpc-url $RPC_URL \
+--broadcast \
 --constructor-args $PYTH_OP_SEPOLIA_ADDRESS $ETH_USD_ID
 ```
 


### PR DESCRIPTION
## Description

Without the `--broadcast` switch, the `forge create` command treats the deployment as a dry run and does not broadcast the transaction as the docs say. 

<img width="605" alt="Screenshot 2025-06-11 at 3 36 52 PM" src="https://github.com/user-attachments/assets/068ca920-c2c9-4e78-bef3-436cca7646e2" />

I don't understand why the [foundry docs](https://getfoundry.sh/forge/deploying#deploying) don't mention this. I'm on forge 1.2.2-stable which appears to be the current version. `forge create --help` makes it clear that `--broadcast` is required. I submitted this doc update for forge: https://github.com/foundry-rs/book/pull/1571


## Type of Change

<!-- Check relevant options by putting an x in the brackets -->

- [ ] New Page
- [ ] Page update/improvement
- [X] Fix typo/grammar
- [ ] Restructure/reorganize content
- [ ] Update links/references
- [ ] Other (please describe):

## Areas Affected

https://docs.pyth.network/price-feeds/create-your-first-pyth-app/evm/part-2

## Checklist

<!-- Check items by putting an x in the brackets -->

- [X] I ran `pre-commit run --all-files` to check for linting errors
- [ ] I have reviewed my changes for clarity and accuracy
- [ ] All links are valid and working
- [ ] Images (if any) are properly formatted and include alt text
- [ ] Code examples (if any) are complete and functional
- [ ] Content follows the established style guide
- [X] Changes are properly formatted in Markdown
- [X] Preview renders correctly in development environment

## Related Issues

<!-- Link any related issues using #issue_number -->

Closes #

## Additional Notes

<!-- Add any other context about your documentation changes -->

## Contributor Information

<!-- Please provide your contact information -->

- Name:
- Email:

## Screenshots

<!-- If applicable, add screenshots to help explain your changes -->
