### PR TITLE
bug(sponsored-fix): correct asset in sui 

### DIFF
--- a/pages/price-feeds/sponsored-feeds/data/sui/sui_mainnet.json
+++ b/pages/price-feeds/sponsored-feeds/data/sui/sui_mainnet.json
@@ -7,7 +7,7 @@
     "confidence_ratio": 100
   },
   {
-    "alias": "ARB/USD",
+    "alias": "ETH/USD",
     "id": "ff61491a931112ddf1bd8147cd1b641375f79f5825126d665480874634fd0ace",
     "time_difference": 3,
     "price_deviation": 0.5,


### PR DESCRIPTION
## Description

There was a typo, instead of ETH there was ARB.

<!-- Provide a clear and concise description of your documentation changes -->

## Type of Change

<!-- Check relevant options by putting an x in the brackets -->

- [ ] New Page
- [ ] Page update/improvement
- [x] Fix typo/grammar
- [ ] Restructure/reorganize content
- [ ] Update links/references
- [ ] Other (please describe):

## Areas Affected

## <!-- List the documentation sections/pages that have been modified -->

## Checklist

<!-- Check items by putting an x in the brackets -->

- [x] I ran `pre-commit run --all-files` to check for linting errors
- [ ] I have reviewed my changes for clarity and accuracy
- [ ] All links are valid and working
- [ ] Images (if any) are properly formatted and include alt text
- [ ] Code examples (if any) are complete and functional
- [ ] Content follows the established style guide
- [ ] Changes are properly formatted in Markdown
- [ ] Preview renders correctly in development environment

## Related Issues

<!-- Link any related issues using #issue_number -->

Closes #

## Additional Notes

<!-- Add any other context about your documentation changes -->

## Contributor Information

<!-- Please provide your contact information -->

- Name:
- Email:

## Screenshots

<img width="1474" height="782" alt="image" src="https://github.com/user-attachments/assets/9ac05154-0237-47cf-8639-8040601d9938" />


<!-- If applicable, add screenshots to help explain your changes -->
