### PR TITLE
chore(enhancement): rename column for gas limit for clarity

### DIFF
--- a/components/EntropyDeploymentTable.tsx
+++ b/components/EntropyDeploymentTable.tsx
@@ -16,7 +16,7 @@ const EntropyDeploymentTable = ({
           <th>Chain Id</th>
           <th>Entropy Contract Address</th>
           {showReveal && <th>Reveal Delay</th>}
-          <th>Gas Limit</th>
+          <th>Default Gas Limit</th>
         </tr>
       </thead>
       <tbody>


### PR DESCRIPTION
## Description
https://docs.pyth.network/entropy/contract-addresses
The table shows the gas limit for the default provider, we should keep it as it differs for the chains, would be useful for folks to refer so they can set their gas limits accordingly.  We can rename the column to "Default Gas Limit" to make it more clear. 

<!-- Provide a clear and concise description of your documentation changes -->

## Type of Change

<!-- Check relevant options by putting an x in the brackets -->

- [ ] New Page
- [x] Page update/improvement
- [ ] Fix typo/grammar
- [ ] Restructure/reorganize content
- [ ] Update links/references
- [ ] Other (please describe):

## Areas Affected

## <!-- List the documentation sections/pages that have been modified -->

## Checklist

<!-- Check items by putting an x in the brackets -->

- [x] I ran `pre-commit run --all-files` to check for linting errors
- [x] I have reviewed my changes for clarity and accuracy
- [ ] All links are valid and working
- [ ] Images (if any) are properly formatted and include alt text
- [ ] Code examples (if any) are complete and functional
- [ ] Content follows the established style guide
- [ ] Changes are properly formatted in Markdown
- [ ] Preview renders correctly in development environment

## Related Issues

<!-- Link any related issues using #issue_number -->

Closes #

## Additional Notes

<!-- Add any other context about your documentation changes -->

## Contributor Information

<!-- Please provide your contact information -->

- Name:
- Email:

## Screenshots
<img width="875" height="482" alt="image" src="https://github.com/user-attachments/assets/6727c4b8-b912-4a5f-ad94-d97c327ffed9" />


<!-- If applicable, add screenshots to help explain your changes -->
