### PR TITLE
chore(entropy v2): correct example link

### DIFF
--- a/pages/entropy/whats-new-entropyv2.mdx
+++ b/pages/entropy/whats-new-entropyv2.mdx
@@ -80,4 +80,4 @@ These following resources will help you get started with Entropy V2:
 - [Entropy V2 Guide](./generate-random-numbers/evm.mdx)
 - [Entropy V2 Contracts](https://github.com/pyth-network/pyth-crosschain/tree/main/target_chains/ethereum/contracts/contracts/entropy)
 - [Entropy V2 SDK](https://github.com/pyth-network/pyth-crosschain/tree/main/target_chains/ethereum/entropy_sdk/solidity)
-- [Entropy V2 Examples](https://github.com/pyth-network/pyth-examples/tree/main/entropy)
+- [Entropy V2 Example](https://github.com/pyth-network/pyth-examples/tree/main/entropy/coin_flip)


### PR DESCRIPTION
## Description

The example link in [What's New in V2](https://docs.pyth.network/entropy/whats-new-entropyv2) used to redirect to https://github.com/pyth-network/pyth-examples/tree/main/entropy which had two examples. The `growing` example is not using v2, which is kinda confusing.

So now the redirection will point to the CoinFlip example which is based on v2.

<!-- Provide a clear and concise description of your documentation changes -->

## Type of Change

<!-- Check relevant options by putting an x in the brackets -->

- [ ] New Page
- [x] Page update/improvement
- [ ] Fix typo/grammar
- [ ] Restructure/reorganize content
- [ ] Update links/references
- [ ] Other (please describe):

## Areas Affected

## <!-- List the documentation sections/pages that have been modified -->

## Checklist

<!-- Check items by putting an x in the brackets -->

- [x] I ran `pre-commit run --all-files` to check for linting errors
- [x] I have reviewed my changes for clarity and accuracy
- [x] All links are valid and working
- [ ] Images (if any) are properly formatted and include alt text
- [ ] Code examples (if any) are complete and functional
- [ ] Content follows the established style guide
- [ ] Changes are properly formatted in Markdown
- [ ] Preview renders correctly in development environment

## Related Issues

<!-- Link any related issues using #issue_number -->

Closes #

## Additional Notes

<!-- Add any other context about your documentation changes -->

## Contributor Information

<!-- Please provide your contact information -->

- Name:
- Email:

## Screenshots

<!-- If applicable, add screenshots to help explain your changes -->
