### PR TITLE
chore(entropy-v2): changes for entropy explorer

### DIFF
--- a/pages/entropy/debug-callback-failures.mdx
+++ b/pages/entropy/debug-callback-failures.mdx
@@ -4,7 +4,7 @@ import { Callout } from "nextra/components";
 
 <Callout type="info" emoji="🔍">
   **Quick Debug Tool**: Use the [Entropy
-  Debugger](https://entropy-debugger.pyth.network/) to quickly diagnose and
+  Explorer](https://entropy-debugger.pyth.network/) to quickly diagnose and
   resolve callback issues.
 </Callout>
 

--- a/pages/entropy/whats-new-entropyv2.mdx
+++ b/pages/entropy/whats-new-entropyv2.mdx
@@ -67,9 +67,9 @@ This updated `Revealed` event
 
 This will help teams to easily track the status of their callbacks and re-request them if they fail on-chain.
 
-### Upcoming Public Entropy Explorer
+### Entropy Explorer
 
-Entropy V2 introduces an upcoming public Entropy Explorer, which will allow teams to easily track the status of their callbacks and re-request them if they fail on-chain.
+Entropy V2 introduces a public Entropy Explorer, which will allow teams to easily track the status of their callbacks and re-request them if they fail on-chain. Here is the link to the [Explorer](https://entropy-explorer.pyth.network/).
 
 This will help teams to easily track the status of their callbacks and re-request them if they fail on-chain.
 

--- a/pages/entropy/whats-new-entropyv2.mdx
+++ b/pages/entropy/whats-new-entropyv2.mdx
@@ -3,13 +3,13 @@
 Entropy V2 is a major update to the Pyth Randomness Protocol.
 
 It introduces a series of developer experience improvements, shaped directly by the feedback of teams using it in production:
-configurable & customizable gas limits for callbacks, adding callback statuses, and an upcoming public Entropy Explorer.
+configurable & customizable gas limits for callbacks, adding callback statuses, and an Entropy Explorer.
 
 ## What's New
 
 - [Configurable Gas Limits for Callbacks](#configurable-gas-limits-for-callbacks)
 - [Enhanced Callback Statuses](#enhanced-callback-statuses)
-- [Upcoming Public Entropy Explorer](#upcoming-public-entropy-explorer)
+- [Entropy Explorer](#entropy-explorer)
 
 ### Configurable Gas Limits for Callbacks
 


### PR DESCRIPTION
## Description

- Docs page https://docs.pyth.network/entropy/whats-new-entropyv2 still says the explorer is upcoming. We should put in a link.
- Should call it Explorer instead of debugger.

<!-- Provide a clear and concise description of your documentation changes -->

## Type of Change

<!-- Check relevant options by putting an x in the brackets -->

- [ ] New Page
- [x] Page update/improvement
- [ ] Fix typo/grammar
- [ ] Restructure/reorganize content
- [x] Update links/references
- [ ] Other (please describe):

## Areas Affected

The Entropy section
## <!-- List the documentation sections/pages that have been modified -->

## Checklist

<!-- Check items by putting an x in the brackets -->

- [x] I ran `pre-commit run --all-files` to check for linting errors
- [x] I have reviewed my changes for clarity and accuracy
- [x] All links are valid and working
- [ ] Images (if any) are properly formatted and include alt text
- [ ] Code examples (if any) are complete and functional
- [ ] Content follows the established style guide
- [ ] Changes are properly formatted in Markdown
- [ ] Preview renders correctly in development environment

## Related Issues

<!-- Link any related issues using #issue_number -->

Closes #

## Additional Notes

<!-- Add any other context about your documentation changes -->

## Contributor Information

<!-- Please provide your contact information -->

- Name:
- Email:

## Screenshots

<!-- If applicable, add screenshots to help explain your changes -->
