### PR TITLE
chore(bug): trading view link fix

### DIFF
--- a/pages/price-feeds/use-historic-price-data.mdx
+++ b/pages/price-feeds/use-historic-price-data.mdx
@@ -104,7 +104,7 @@ Refer to the [parsePriceFeedUpdates](https://api-reference.pyth.network/price-fe
 
 ### TradingView Integration
 
-- [TradingView integration](../create-tradingview-charts) for visualization.
+- [TradingView integration](./create-tradingview-charts) for visualization.
 
 ### Rate Limits
 


### PR DESCRIPTION
## Description

[Trading view Integration](https://docs.pyth.network/price-feeds/use-historic-price-data#tradingview-integration) link is broken. It returns 404, Page not Found.
<img width="764" height="628" alt="image" src="https://github.com/user-attachments/assets/b555f4d0-fd4d-4370-ba14-a60433d23488" />

<!-- Provide a clear and concise description of your documentation changes -->

## Type of Change

<!-- Check relevant options by putting an x in the brackets -->

- [ ] New Page
- [ ] Page update/improvement
- [ ] Fix typo/grammar
- [ ] Restructure/reorganize content
- [x] Update links/references
- [ ] Other (please describe):

## Areas Affected

## <!-- List the documentation sections/pages that have been modified -->

## Checklist

<!-- Check items by putting an x in the brackets -->

- [x] I ran `pre-commit run --all-files` to check for linting errors
- [x] I have reviewed my changes for clarity and accuracy
- [x] All links are valid and working
- [ ] Images (if any) are properly formatted and include alt text
- [ ] Code examples (if any) are complete and functional
- [ ] Content follows the established style guide
- [ ] Changes are properly formatted in Markdown
- [ ] Preview renders correctly in development environment

## Related Issues

<!-- Link any related issues using #issue_number -->

Closes #

## Additional Notes

<!-- Add any other context about your documentation changes -->

## Contributor Information

<!-- Please provide your contact information -->

- Name:
- Email:

## Screenshots

<!-- If applicable, add screenshots to help explain your changes -->
