### PR TITLE
chore(bug): example of Trading View Symbols fix

### DIFF
--- a/pages/price-feeds/create-tradingview-charts.mdx
+++ b/pages/price-feeds/create-tradingview-charts.mdx
@@ -145,5 +145,5 @@ The datafeed URL is [here](https://benchmarks.pyth.network/v1/shims/tradingview)
 - History: https://benchmarks.pyth.network/v1/shims/tradingview/history?symbol=Crypto.ETH/USD&resolution=1&from=1690338541&to=1690338741
 - Stream of prices: https://benchmarks.pyth.network/v1/shims/tradingview/streaming
 - Config: https://benchmarks.pyth.network/v1/shims/tradingview/config
-- Symbols: https://benchmarks.pyth.network/v1/shims/tradingview/symbols?symbol=crypto.btc/usd
+- Symbols: https://benchmarks.pyth.network/v1/shims/tradingview/symbols?symbol=Crypto.BTC/USD
 - Search: https://benchmarks.pyth.network/v1/shims/tradingview/search?query=bitcoin


### PR DESCRIPTION
## Description

In [TradingView examples](https://docs.pyth.network/price-feeds/create-tradingview-charts#example), for symbols https://benchmarks.pyth.network/v1/shims/tradingview/symbols?symbol=crypto.btc/usd , getting error as Symbol crypto.btc/usd doesn't exist

This is due to the case-sensitivity of the symbols. 

<img width="979" height="393" alt="image" src="https://github.com/user-attachments/assets/64cc0764-0e44-4baa-9261-ceab13d8e317" />


<!-- Provide a clear and concise description of your documentation changes -->

## Type of Change

<!-- Check relevant options by putting an x in the brackets -->

- [ ] New Page
- [ ] Page update/improvement
- [ ] Fix typo/grammar
- [ ] Restructure/reorganize content
- [x] Update links/references
- [ ] Other (please describe):

## Areas Affected
Create Trading View 
## <!-- List the documentation sections/pages that have been modified -->

## Checklist

<!-- Check items by putting an x in the brackets -->

- [x] I ran `pre-commit run --all-files` to check for linting errors
- [x] I have reviewed my changes for clarity and accuracy
- [x] All links are valid and working
- [ ] Images (if any) are properly formatted and include alt text
- [ ] Code examples (if any) are complete and functional
- [ ] Content follows the established style guide
- [ ] Changes are properly formatted in Markdown
- [ ] Preview renders correctly in development environment

## Related Issues

<!-- Link any related issues using #issue_number -->

Closes #

## Additional Notes

<!-- Add any other context about your documentation changes -->

## Contributor Information

<!-- Please provide your contact information -->

- Name:
- Email:

## Screenshots
<img width="952" height="156" alt="image" src="https://github.com/user-attachments/assets/9e2e2209-15ae-4a04-8966-2572edfbf29c" />


<!-- If applicable, add screenshots to help explain your changes -->
