### PR TITLE
chore(bug): broken links fix for metrics page

### DIFF
--- a/pages/home/metrics/publisher-metrics.mdx
+++ b/pages/home/metrics/publisher-metrics.mdx
@@ -30,7 +30,7 @@ The **calibration graph** shows how closely the publisher's prices and confidenc
 
 **Accessing the Metrics**
 
-You can start at the [Pyth Price Feeds page](https://pyth.network/price-feeds/), which will list every market symbol (“price feed”). Clicking on any price feed will bring you to the corresponding market page. Here is an example of the [SOL/USD price page](https://pyth.network/price-feeds/#Crypto.SOL/USD).
+You can start at the [Pyth Price Feeds page](https://insights.pyth.network/price-feeds), which will list every market symbol (“price feed”). Clicking on any price feed will bring you to the corresponding market page. Here is an example of the [SOL/USD price page](https://insights.pyth.network/price-feeds/Crypto.SOL%2FUSD).
 
 Each price feed page has a list of price components (representing each publisher by their publisher keys). Each component will link to the corresponding Publisher Metrics page.
 
@@ -44,6 +44,6 @@ To open the metrics for another publisher (of that same price feed), you can cli
 
 ![](../../../images/publisher-metrics/Publisher_metrics_image_2.jpg)
 
-If you want to review the Publisher Metrics of another price feed (e.g. ETH/USD), you will need to access the relevant asset. As mentioned, the [Pyth Price Feeds page](https://pyth.network/price-feeds/) has the full list of price feeds.
+If you want to review the Publisher Metrics of another price feed (e.g. ETH/USD), you will need to access the relevant asset. As mentioned, the [Pyth Price Feeds page](https://insights.pyth.network/price-feeds) has the full list of price feeds.
 
 For more details on the Pyth Publishers Metrics, please visit this [blog post](https://pythnetwork.medium.com/introducing-pyth-publishers-metrics-3b20de6f1bf3).


### PR DESCRIPTION
## Description

[Pyth Publisher Metrics](https://docs.pyth.network/home/metrics/publisher-metrics) broken link
<!-- Provide a clear and concise description of your documentation changes -->

## Type of Change

<!-- Check relevant options by putting an x in the brackets -->

- [ ] New Page
- [ ] Page update/improvement
- [ ] Fix typo/grammar
- [ ] Restructure/reorganize content
- [x] Update links/references
- [ ] Other (please describe):

## Areas Affected

## <!-- List the documentation sections/pages that have been modified -->

## Checklist

<!-- Check items by putting an x in the brackets -->

- [x] I ran `pre-commit run --all-files` to check for linting errors
- [x] I have reviewed my changes for clarity and accuracy
- [x] All links are valid and working
- [ ] Images (if any) are properly formatted and include alt text
- [ ] Code examples (if any) are complete and functional
- [ ] Content follows the established style guide
- [ ] Changes are properly formatted in Markdown
- [ ] Preview renders correctly in development environment

## Related Issues

<!-- Link any related issues using #issue_number -->

Closes #

## Additional Notes

<!-- Add any other context about your documentation changes -->

## Contributor Information

<!-- Please provide your contact information -->

- Name:
- Email:

## Screenshots

<!-- If applicable, add screenshots to help explain your changes -->
