### PR TITLE
Fix HermesClient import in docs

### DIFF
--- a/pages/price-feeds/core/create-your-first-pyth-app/evm/part-2.mdx
+++ b/pages/price-feeds/core/create-your-first-pyth-app/evm/part-2.mdx
@@ -176,7 +176,7 @@ Then open `src/mintNft.ts` and paste in the following content:
 import { createWalletClient, http, parseEther } from "viem";
 import { privateKeyToAccount } from "viem/accounts";
 import { optimismSepolia } from "viem/chains";
-import { EvmPriceServiceConnection } from "@pythnetwork/hermes-client";
+import { HermesClient } from "@pythnetwork/hermes-client";
 import { getContract } from "viem";
 
 export const abi = [


### PR DESCRIPTION
## Description

<!-- Provide a clear and concise description of your documentation changes -->


### Fix incorrect import in documentation

The example was importing `EvmPriceServiceConnection` even though the code uses `HermesClient`.  
This PR updates the import statement to:

```ts
import { HermesClient } from "@pythnetwork/hermes-client";
````

This ensures the example runs correctly and matches the intended API usage.



## Type of Change

<!-- Check relevant options by putting an x in the brackets -->

- [ ] New Page
- [x] Page update/improvement
- [ ] Fix typo/grammar
- [ ] Restructure/reorganize content
- [ ] Update links/references
- [ ] Other (please describe):

## Areas Affected

## <!-- List the documentation sections/pages that have been modified -->

## Checklist

<!-- Check items by putting an x in the brackets -->

- [x] I ran `pre-commit run --all-files` to check for linting errors
- [x] I have reviewed my changes for clarity and accuracy
- [x] All links are valid and working
- [x] Images (if any) are properly formatted and include alt text
- [x] Code examples (if any) are complete and functional
- [x] Content follows the established style guide
- [x] Changes are properly formatted in Markdown
- [x] Preview renders correctly in development environment


## Additional Notes

<!-- Add any other context about your documentation changes -->

## Contributor Information

<!-- Please provide your contact information -->

- Name: Zeel Darji
- Email:darjizeel587@gmail.com
